### PR TITLE
[feature] change caption of main window

### DIFF
--- a/src/Idler/MainWindow.xaml
+++ b/src/Idler/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:Idler"
         mc:Ignorable="d"
         DataContext="{Binding RelativeSource={RelativeSource Self}}"
-        Title="MainWindow" Height="450" Width="800">
+        Title="{Binding FullAppName}" Height="450" Width="800">
     <Window.Resources>
         <CollectionViewSource x:Key="NoteCategoriesList" Source="{Binding NoteCategories.Categories}" />
     </Window.Resources>

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -24,9 +25,21 @@ namespace Idler
     /// </summary>
     public partial class MainWindow : Window, INotifyPropertyChanged
     {
+        private const string appName = "Idler";
         private Shift currentShift;
+        private string fullAppName;
         private NoteCategories noteCategories = new NoteCategories();
         private bool isBusy;
+
+        public string FullAppName
+        {
+            get => this.fullAppName;
+            set
+            {
+                this.fullAppName = value;
+                OnPropertyChanged(nameof(this.FullAppName));
+            }
+        }
 
         public Shift CurrentShift
         {
@@ -63,6 +76,9 @@ namespace Idler
         public MainWindow()
         {
             Trace.TraceInformation("Initializing main window");
+
+            Version appVersion = Assembly.GetExecutingAssembly().GetName().Version;
+            this.fullAppName = $"{appName} ({appVersion.Major}.{appVersion.Minor})";
 
             InitializeComponent();
 

--- a/src/Idler/Properties/AssemblyInfo.cs
+++ b/src/Idler/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.8")]
+[assembly: AssemblyFileVersion("0.8.0.0")]


### PR DESCRIPTION
### Description of problem

- main window contains `MainWindow` in title. We need to change it to follow: `<Application Name> (<Major Version>.<Minor Version>)

### Description of fix

- filled out version in `AssemblyInfo.cs`
- implemented logic to display application name and version in main window's title