### PR TITLE
[feature] Implement menu "Help"

### DIFF
--- a/src/Idler/About.xaml
+++ b/src/Idler/About.xaml
@@ -1,0 +1,27 @@
+﻿<Window x:Class="Idler.About"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Idler"
+        mc:Ignorable="d"
+        Title="About" ResizeMode="NoResize">
+    <Grid>
+        <StackPanel Margin="10" Orientation="Vertical">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="Idler" FontSize="18" FontWeight="Bold" Margin="0,0,5,0" />
+                <TextBlock Text="(0.8)" Foreground="Gray" />
+            </StackPanel>
+            <TextBlock Text="The application helps to track your work activity" Margin="0,10,0,0" />
+            <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
+                <TextBlock Margin="0,0,5,0" FontWeight="Bold">Author:</TextBlock>
+                <TextBlock Margin="0,0,5,0">Koryshev Sergey</TextBlock>
+            </StackPanel>
+            <TextBlock Margin="0,15,0,0">           
+                <Hyperlink NavigateUri="https://github.com/sergey-koryshev/Idler" RequestNavigate="Hyperlink_RequestNavigate">
+                    GitHub Page
+                </Hyperlink>
+            </TextBlock>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/Idler/About.xaml
+++ b/src/Idler/About.xaml
@@ -5,20 +5,21 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Idler"
         mc:Ignorable="d"
-        Title="About" ResizeMode="NoResize">
+        DataContext="{Binding RelativeSource={RelativeSource Self}}"
+        Title="About" ResizeMode="NoResize" SizeToContent="WidthAndHeight">
     <Grid>
         <StackPanel Margin="10" Orientation="Vertical">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="Idler" FontSize="18" FontWeight="Bold" Margin="0,0,5,0" />
-                <TextBlock Text="(0.8)" Foreground="Gray" />
+                <TextBlock Text="{Binding Version}" Foreground="Gray" />
             </StackPanel>
             <TextBlock Text="The application helps to track your work activity" Margin="0,10,0,0" />
             <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-                <TextBlock Margin="0,0,5,0" FontWeight="Bold">Author:</TextBlock>
-                <TextBlock Margin="0,0,5,0">Koryshev Sergey</TextBlock>
+                <TextBlock Margin="0,0,5,0" >Author:</TextBlock>
+                <TextBlock Margin="0,0,5,0">Sergey Koryshev</TextBlock>
             </StackPanel>
             <TextBlock Margin="0,15,0,0">           
-                <Hyperlink NavigateUri="https://github.com/sergey-koryshev/Idler" RequestNavigate="Hyperlink_RequestNavigate">
+                <Hyperlink NavigateUri="https://github.com/sergey-koryshev/Idler" RequestNavigate="gitHubLinkClicked">
                     GitHub Page
                 </Hyperlink>
             </TextBlock>

--- a/src/Idler/About.xaml.cs
+++ b/src/Idler/About.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace Idler
+{
+    /// <summary>
+    /// Interaction logic for About.xaml
+    /// </summary>
+    public partial class About : Window
+    {
+        public About()
+        {
+            InitializeComponent();
+        }
+
+        private void Hyperlink_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
+        {
+
+        }
+    }
+}

--- a/src/Idler/About.xaml.cs
+++ b/src/Idler/About.xaml.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -17,16 +20,37 @@ namespace Idler
     /// <summary>
     /// Interaction logic for About.xaml
     /// </summary>
-    public partial class About : Window
+    public partial class About : Window, INotifyPropertyChanged
     {
+        private string version;
+
+        public string Version
+        {
+            get { return version; }
+            set { 
+                version = value;
+                this.OnPropertyChanged(this.Version);
+            }
+        }
+
+
         public About()
         {
+            Version appVersion = Assembly.GetExecutingAssembly().GetName().Version;
+            this.Version = $"({appVersion.Major}.{appVersion.Minor})";
             InitializeComponent();
         }
 
-        private void Hyperlink_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
+        public event PropertyChangedEventHandler PropertyChanged;
+        public void OnPropertyChanged(string propertyName)
         {
+            this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
 
+        private void gitHubLinkClicked(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
+            e.Handled = true;
         }
     }
 }

--- a/src/Idler/Idler.csproj
+++ b/src/Idler/Idler.csproj
@@ -95,6 +95,9 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="About.xaml.cs">
+      <DependentUpon>About.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Helpers\AdvancedTextWriterTraceListener.cs" />
     <Compile Include="Helpers\MVVM\ObservableObject.cs" />
     <Compile Include="Helpers\MVVM\UpdatableObject.cs" />
@@ -108,6 +111,10 @@
     <Compile Include="Shift.cs" />
     <Compile Include="ShiftNote.cs" />
     <Compile Include="Interfaces\IUpdatable.cs" />
+    <Page Include="About.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/Idler/MainWindow.xaml
+++ b/src/Idler/MainWindow.xaml
@@ -22,6 +22,10 @@
             <MenuItem Header="Options">
                 <MenuItem x:Name="mnuSettings" Header="Settings..." Click="MnuSettings_Click" />
             </MenuItem>
+            <MenuItem Header="Help">
+                <MenuItem Header="Content" Click="MnuContent_Click" />
+                <MenuItem Header="About..." Click="MnuAbout_Click" />
+            </MenuItem>
         </Menu>
         <Grid Grid.Row="1">
             <DockPanel Background="#7F646464">

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -78,7 +78,7 @@ namespace Idler
             Trace.TraceInformation("Initializing main window");
 
             Version appVersion = Assembly.GetExecutingAssembly().GetName().Version;
-            this.fullAppName = $"{appName} ({appVersion.Major}.{appVersion.Minor})";
+            this.FullAppName = $"{appName} ({appVersion.Major}.{appVersion.Minor})";
 
             InitializeComponent();
 
@@ -233,6 +233,17 @@ namespace Idler
         private void MnuExit_Click(object sender, RoutedEventArgs e)
         {
             System.Windows.Application.Current.Shutdown();
+        }
+
+        private void MnuAbout_Click(object sender, RoutedEventArgs e)
+        {
+            About aboutWindow = new About();
+            aboutWindow.ShowDialog();
+        }
+
+        private void MnuContent_Click(object sender, RoutedEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo("https://github.com/sergey-koryshev/Idler/tree/release/poc"));
         }
     }
 }


### PR DESCRIPTION
### Description of problem

- need to implement menu `Help`. It should contain two items: `Content` and `About`. `Content` should lead to GitHub related page and `About` should open window with information about the application

### Description of fix

- added new window `About` which shows follow information
  - name and version of the application
  - description of the application
  - author's name
  - link to application's GitHub page: `https://github.com/sergey-koryshev/Idler`
- introduced new menu group `Help`. It contains follow items:
  - `Content` - opens page `https://github.com/sergey-koryshev/Idler/tree/release/poc` in browser
  - `About` - opens window `About`