### PR TITLE
[bug] User cannot specify different path to data base file

### DIFF
--- a/src/Idler/SettingsWindow.xaml
+++ b/src/Idler/SettingsWindow.xaml
@@ -29,12 +29,12 @@
         <TextBlock Text="Data Source:" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Padding="0,5" />
         <DockPanel Grid.Column="2" Grid.Row="0">
             <Button x:Name="btnDataSourceOpen" Content="Open Data Source..." Padding="25,5" DockPanel.Dock="Right" Margin="5,0,0,0" Click="btnDataSourceOpen_Click" />
-            <TextBox x:Name="txtDataSource" VerticalContentAlignment="Center" Text="{Binding DataSource, Source={x:Static properties:Settings.Default}}" />
+            <TextBox x:Name="txtDataSource" VerticalContentAlignment="Center" Text="{Binding DataSource, UpdateSourceTrigger=PropertyChanged, Source={x:Static properties:Settings.Default}}" />
         </DockPanel>
 
         <TextBlock Text="Data Provider:" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Padding="0,5" />
-        <TextBox x:Name="txtDataProvider" Grid.Column="2" Grid.Row="2" VerticalContentAlignment="Center" Text="{Binding ProviderName, Source={x:Static properties:Settings.Default}}" />
-        <TextBlock Padding="0,5" Text="Note Collection:" DockPanel.Dock="Top" Grid.Row="4" Grid.Column="0"/>
+        <TextBox x:Name="txtDataProvider" Grid.Column="2" Grid.Row="2" VerticalContentAlignment="Center" Text="{Binding ProviderName, UpdateSourceTrigger=PropertyChanged, Source={x:Static properties:Settings.Default}}" />
+        <TextBlock Padding="0,5" Text="Note Categories:" DockPanel.Dock="Top" Grid.Row="4" Grid.Column="0"/>
         <DataGrid Grid.Row="6" Grid.ColumnSpan="3" AutoGenerateColumns="False" ItemsSource="{Binding NoteCategories.Categories}">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Name" Binding="{Binding Name}" />


### PR DESCRIPTION
### Description of problem

- user cannot save new path to source because of property is changed only when field lost focus
- name of table with note categories are wrong

### Description of fix

- set `UpdateSourceTrigger` to `PropertyChanged` in binging for Source and Data Provider fields
- changed name of note categories table

Issue: #15, #14