### PR TITLE
Total Effort is not updated when a note is deleted

### DIFF
--- a/src/Idler/Properties/AssemblyInfo.cs
+++ b/src/Idler/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Windows;
 )]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.14")]
-[assembly: AssemblyInformationalVersion("1.2.0.14")]
+[assembly: AssemblyFileVersion("1.2.1.14")]
+[assembly: AssemblyInformationalVersion("1.2.1.14")]

--- a/src/Idler/Shift.cs
+++ b/src/Idler/Shift.cs
@@ -127,6 +127,8 @@ namespace Idler
                     }
                     break;
             }
+
+            OnPropertyChanged(nameof(this.TotalEffort));
         }
 
         /// <summary>
@@ -331,7 +333,6 @@ ORDER BY {Shift.idFieldName}";
         public void AddNewShiftNote(ShiftNote shiftNote)
         {
             this.Notes.Add(shiftNote);
-            OnPropertyChanged(nameof(this.TotalEffort));
         }
 
         public static async Task<int?> GetLastShiftId()


### PR DESCRIPTION
### Description of issue

- `Total Effort` counter is not updated when a note is deleted due to UI is not notified about fact of deleting the note

### Description of fix

- implemented logic to notify UI about changing note collection

### Screenshot

![Animation](https://user-images.githubusercontent.com/11807074/197405360-9b292cdd-9dcb-44f5-82ca-78645d66788c.gif)