### PR TITLE
Idler shows non-zero total effort for new shift

### DIFF
--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -231,6 +231,7 @@ namespace Idler
                     Name = Shift.unnamedShiftPrevix,
                     PreviousShiftId = this.CurrentShift.Id
                 };
+                OnPropertyChanged(nameof(this.TotalEffort));
             }
         }
 

--- a/src/Idler/Properties/AssemblyInfo.cs
+++ b/src/Idler/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Windows;
 )]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.2.1.15")]
-[assembly: AssemblyInformationalVersion("1.2.1.15")]
+[assembly: AssemblyFileVersion("1.2.2.15")]
+[assembly: AssemblyInformationalVersion("1.2.2.15")]


### PR DESCRIPTION
### Description of issue

- `Total Effort` counter doesn't equal to `0` because of missed logic to recalculate the property when new shift is created

### Description of fix

- rise event `PropertyChanged` when new shift is created

### Screenshot

![Animation](https://user-images.githubusercontent.com/11807074/197420093-8d5f61cb-1b30-4e0d-9af9-743f5e4cf7d8.gif)
