### PR TITLE
Spellcheck doesn't work properly during note creation

### DIFF
--- a/src/Idler/Properties/AssemblyInfo.cs
+++ b/src/Idler/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Windows;
 )]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.2.2.16")]
-[assembly: AssemblyInformationalVersion("1.2.2.16")]
+[assembly: AssemblyFileVersion("1.2.3.16")]
+[assembly: AssemblyInformationalVersion("1.2.3.16")]

--- a/src/Idler/ViewModels/AddNoteViewModel.cs
+++ b/src/Idler/ViewModels/AddNoteViewModel.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Markup;
 
 namespace Idler.ViewModels
 {
@@ -18,6 +19,7 @@ namespace Idler.ViewModels
         private string description;
         private DateTime startTime;
         private Shift shift;
+        private XmlLanguage spellcheckLanguage;
         private ICommand addNoteCommand;
 
         public Shift Shift
@@ -90,6 +92,17 @@ namespace Idler.ViewModels
             }
         }
 
+        public XmlLanguage SpellcheckLanguage
+        {
+            get { return spellcheckLanguage; }
+            set
+            {
+                spellcheckLanguage = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+
         public ICommand AddNoteCommand
         {
             get { return addNoteCommand; }
@@ -104,6 +117,14 @@ namespace Idler.ViewModels
         {
             this.StartTime = DateTime.Now;
             this.PropertyChanged += AddNoteViewModelPropertyChanged;
+            var currentLanguageManager = InputLanguageManager.Current;
+            this.SpellcheckLanguage = XmlLanguage.GetLanguage(currentLanguageManager.CurrentInputLanguage.Name);
+            currentLanguageManager.InputLanguageChanged += InputLanguageChanged;
+        }
+
+        private void InputLanguageChanged(object sender, InputLanguageEventArgs e)
+        {
+            this.SpellcheckLanguage = XmlLanguage.GetLanguage(e.NewLanguage.Name);
         }
 
         private void AddNoteViewModelPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Idler/Views/AddNoteView.xaml
+++ b/src/Idler/Views/AddNoteView.xaml
@@ -37,6 +37,7 @@
                     Padding="5,0"
                     VerticalContentAlignment="Center"/>
         <TextBox SpellCheck.IsEnabled="True"
+                 Language="{Binding SpellcheckLanguage}"
                  TabIndex="3"
                  Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
                  VerticalContentAlignment="Center"


### PR DESCRIPTION
### Description of issue

- spellcheck language is not changed when user changes input language

### Description of fix

- implemented logic to set language which is used in spellcheck when user changes input language

### Screenshot

![Animation](https://user-images.githubusercontent.com/11807074/197422766-a5817e34-55f3-430b-8dcd-8b785849b15e.gif)