### PR TITLE
Correct name of workflow which triggers dev-build

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -4,7 +4,7 @@ run-name: Developer Build @${{ github.sha }}
 
 on:
   workflow_run:
-    workflows: [Create Label]
+    workflows: [Create Version Label]
     types:
       - completed
     branches:


### PR DESCRIPTION
Dev-build is not started by `Create Version Label` due to incorrect name of workflow