### PR TITLE
[bug] Reminders ignore recently created notes

### DIFF
--- a/src/Idler/Commands/AddNoteCommand.cs
+++ b/src/Idler/Commands/AddNoteCommand.cs
@@ -48,6 +48,7 @@ namespace Idler.Commands
             };
             this.shift.AddNewShiftNote(note);
             this.addNoteViewModel.ResetFields();
+            this.shift.ResetReminder();
         }
     }
 }

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -1,7 +1,5 @@
 ﻿using Idler.Commands;
-using Idler.Helpers.DB;
 using Idler.ViewModels;
-using Microsoft.Toolkit.Uwp.Notifications;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -9,7 +7,6 @@ using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Threading;
 
 namespace Idler
 {
@@ -25,7 +22,6 @@ namespace Idler
         private AddNoteViewModel addNoteViewModel;
         private DateTime selectedDate;
         private ICommand saveShiftCommand;
-        private DispatcherTimer reminder;
         private Shift currentShift;
 
         public AddNoteViewModel AddNoteViewModel
@@ -128,12 +124,9 @@ namespace Idler
         {
             Trace.TraceInformation("Initializing main window");
 
-            Properties.Settings.Default.SettingsSaving += OnSettignsSaving;
 
             var version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
             this.FullAppName = $"{appName} ({version})";
-
-            this.InitializeReminer();
 
             InitializeComponent();
 
@@ -151,49 +144,6 @@ namespace Idler
                     Trace.TraceError($"Error has been occurred during initial loading notes: {action.Exception}");
                 }
             });
-        }
-
-        private void OnSettignsSaving(object sender, CancelEventArgs e)
-        {
-            this.reminder.Interval = Properties.Settings.Default.ReminderInterval;
-            if (Properties.Settings.Default.ReminderInterval.Ticks > 0 && Properties.Settings.Default.IsReminderEnabled)
-            {
-                this.reminder.Start();
-            }
-            else
-            {
-                this.reminder.Stop();
-            }
-        }
-
-        private void InitializeReminer()
-        {
-            this.reminder = new DispatcherTimer();
-            this.reminder.Tick += OnReminderActivated;
-            this.reminder.Interval = Properties.Settings.Default.ReminderInterval;
-            if (Properties.Settings.Default.ReminderInterval.Ticks > 0 && Properties.Settings.Default.IsReminderEnabled)
-            {
-
-                this.reminder.Start();
-            }
-            else
-            {
-                this.reminder.Stop();
-            }
-        }
-
-        private void OnReminderActivated(object sender, EventArgs e)
-        {
-            if (!this.IsInitialized)
-            {
-                return;
-            }
-            new ToastContentBuilder()
-                .AddArgument("action", "remindFillReport")
-                .AddAppLogoOverride(new Uri(System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources/reminder-icon.png")))
-                .AddText("Idler Reminder")
-                .AddText("Hey! Just remind you to fill your current work progress.")
-                .Show();
         }
 
         private async Task InitialLoadingShiftNotes()

--- a/src/Idler/Shift.cs
+++ b/src/Idler/Shift.cs
@@ -63,6 +63,17 @@ namespace Idler
             }
         }
 
+        /// <summary>
+        /// Returns true if reminder is enabled
+        /// </summary>
+        private Boolean IsReminderEnabled
+        {
+            get =>
+                Properties.Settings.Default.ReminderInterval.Ticks > 0 &&
+                Properties.Settings.Default.IsReminderEnabled;
+        }
+
+
         public Shift()
         {
             this.Notes.CollectionChanged += NotesCollectionChangedHandler;
@@ -169,12 +180,10 @@ namespace Idler
             this.Notes.Add(shiftNote);
         }
 
-
-
         private void OnSettignsSaving(object sender, CancelEventArgs e)
         {
             this.reminder.Interval = Properties.Settings.Default.ReminderInterval;
-            if (Properties.Settings.Default.ReminderInterval.Ticks > 0 && Properties.Settings.Default.IsReminderEnabled)
+            if (this.IsReminderEnabled)
             {
                 this.reminder.Start();
             }
@@ -189,9 +198,8 @@ namespace Idler
             this.reminder = new DispatcherTimer();
             this.reminder.Tick += OnReminderActivated;
             this.reminder.Interval = Properties.Settings.Default.ReminderInterval;
-            if (Properties.Settings.Default.ReminderInterval.Ticks > 0 && Properties.Settings.Default.IsReminderEnabled)
+            if (this.IsReminderEnabled)
             {
-
                 this.reminder.Start();
             }
             else
@@ -217,11 +225,11 @@ namespace Idler
 
         public void ResetReminder()
         {
-            if (this.reminder.IsEnabled)
+            if (this.IsReminderEnabled)
             {
                 this.reminder.Stop();
                 this.reminder.Start();
             }
-        }
+        }        
     }
 }

--- a/src/Idler/Shift.cs
+++ b/src/Idler/Shift.cs
@@ -214,5 +214,14 @@ namespace Idler
                 .AddText("Hey! Just remind you to fill your current work progress.")
                 .Show();
         }
+
+        public void ResetReminder()
+        {
+            if (this.reminder.IsEnabled)
+            {
+                this.reminder.Stop();
+                this.reminder.Start();
+            }
+        }
     }
 }

--- a/src/Idler/Shift.cs
+++ b/src/Idler/Shift.cs
@@ -1,6 +1,7 @@
 ﻿using Idler.Helpers.DB;
 using Idler.Helpers.MVVM;
 using Idler.Interfaces;
+using Microsoft.Toolkit.Uwp.Notifications;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -11,6 +12,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Threading;
 
 namespace Idler
 {
@@ -23,6 +25,8 @@ namespace Idler
 
         private ObservableCollection<ShiftNote> notes = new ObservableCollection<ShiftNote>();
         private DateTime selectedDate;
+        private DispatcherTimer reminder;
+        private bool ignorefirstReminder = true;
 
         /// <summary>
         /// Gets/sets collection of Shift Notes
@@ -62,6 +66,8 @@ namespace Idler
         public Shift()
         {
             this.Notes.CollectionChanged += NotesCollectionChangedHandler;
+            Properties.Settings.Default.SettingsSaving += OnSettignsSaving;
+            this.InitializeReminer();
         }
 
         private void NotesCollectionChangedHandler(object sender, NotifyCollectionChangedEventArgs e)
@@ -161,6 +167,52 @@ namespace Idler
         public void AddNewShiftNote(ShiftNote shiftNote)
         {
             this.Notes.Add(shiftNote);
+        }
+
+
+
+        private void OnSettignsSaving(object sender, CancelEventArgs e)
+        {
+            this.reminder.Interval = Properties.Settings.Default.ReminderInterval;
+            if (Properties.Settings.Default.ReminderInterval.Ticks > 0 && Properties.Settings.Default.IsReminderEnabled)
+            {
+                this.reminder.Start();
+            }
+            else
+            {
+                this.reminder.Stop();
+            }
+        }
+
+        private void InitializeReminer()
+        {
+            this.reminder = new DispatcherTimer();
+            this.reminder.Tick += OnReminderActivated;
+            this.reminder.Interval = Properties.Settings.Default.ReminderInterval;
+            if (Properties.Settings.Default.ReminderInterval.Ticks > 0 && Properties.Settings.Default.IsReminderEnabled)
+            {
+
+                this.reminder.Start();
+            }
+            else
+            {
+                this.reminder.Stop();
+            }
+        }
+
+        private void OnReminderActivated(object sender, EventArgs e)
+        {
+            if (this.ignorefirstReminder)
+            {
+                this.ignorefirstReminder = false;
+                return;
+            }
+            new ToastContentBuilder()
+                .AddArgument("action", "remindFillReport")
+                .AddAppLogoOverride(new Uri(System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources/reminder-icon.png")))
+                .AddText("Idler Reminder")
+                .AddText("Hey! Just remind you to fill your current work progress.")
+                .Show();
         }
     }
 }


### PR DESCRIPTION
### Description of issue

Reminder's timer ignores recently created notes and display notification despite the fact that user created some note a moment ago. This happens due to we don't have a logic to reset the timer when new note is added

### Description of fix

- moved logic related to reminder to `Shift` class to get access to it from `AddNoteCommand`
- added method `ResetReminder` to reset the timer