### PR TITLE
[bug] Categories are not updated in the list when user changes their visibility

### DIFF
--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -133,6 +133,7 @@ namespace Idler
             this.PropertyChanged += MainWindowPropertyChangedHandler;
 
             this.NoteCategories = new NoteCategories();
+            this.NoteCategories.UpdateCompleted += NotecategoriesUpdateComletedHandler;
 
             this.isBusy = true;
 
@@ -143,7 +144,12 @@ namespace Idler
                 {
                     Trace.TraceError($"Error has been occurred during initial loading notes: {action.Exception}");
                 }
-            });
+            }); 
+        }
+
+        private void NotecategoriesUpdateComletedHandler(object sender, EventArgs e)
+        {
+            this.AddNoteViewModel?.RefreshFilteredNoteCategoriesView();
         }
 
         private async Task InitialLoadingShiftNotes()

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -133,7 +133,7 @@ namespace Idler
             this.PropertyChanged += MainWindowPropertyChangedHandler;
 
             this.NoteCategories = new NoteCategories();
-            this.NoteCategories.UpdateCompleted += NotecategoriesUpdateComletedHandler;
+            this.NoteCategories.UpdateCompleted += NoteCategoriesUpdateComletedHandler;
 
             this.isBusy = true;
 
@@ -147,7 +147,7 @@ namespace Idler
             }); 
         }
 
-        private void NotecategoriesUpdateComletedHandler(object sender, EventArgs e)
+        private void NoteCategoriesUpdateComletedHandler(object sender, EventArgs e)
         {
             this.AddNoteViewModel?.RefreshFilteredNoteCategoriesView();
         }

--- a/src/Idler/NoteCategories.cs
+++ b/src/Idler/NoteCategories.cs
@@ -113,6 +113,8 @@ namespace Idler
         /// </summary>
         public override async Task UpdateAsync()
         {
+            this.OnUpdateStarted();
+
             string query = null;
 
             foreach (NoteCategory category in this.Categories.Where(c => c.Changed == true))
@@ -181,6 +183,8 @@ WHERE
             {
                 await RemoveCategoryById(id);
             }
+
+            this.OnUpdateCompleted();
         }
 
         public static async Task<DataTable> GetCategories()

--- a/src/Idler/ViewModels/AddNoteViewModel.cs
+++ b/src/Idler/ViewModels/AddNoteViewModel.cs
@@ -167,5 +167,10 @@ namespace Idler.ViewModels
 
             return false;
         }
+
+        public void RefreshFilteredNoteCategoriesView()
+        {
+            this.FilteredNoteCategories.Refresh();
+        }
     }
 }


### PR DESCRIPTION
### Description of issue

Changing `hidden` attribute of categories is not reflected in creating note drop box because of missed logic to refresh the drop box view when only properties of categories are changed.

### Description of fix

Implemented logic to refresh the drop box view after each updating of `NoteCategories` class