### PR TITLE
[bug] Can't see full name of category

### DIFF
--- a/src/Idler/Views/AddNoteView.xaml
+++ b/src/Idler/Views/AddNoteView.xaml
@@ -12,12 +12,18 @@
         </DockPanel.InputBindings>
         <ComboBox Width="150px"
                   TabIndex="1"
-                  DisplayMemberPath="Name"
                   ItemsSource="{Binding FilteredNoteCategories}"
                   SelectedValuePath="Id"
                   SelectedValue="{Binding CategoryId}"
                   VerticalContentAlignment="Center"
-                  Margin="0,0,5,0" />
+                  Margin="0,0,5,0" 
+                  ToolTip="{Binding Path=SelectedItem.Name, RelativeSource={RelativeSource Self}}">
+            <ComboBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis" />
+                </DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
         <TextBox Width="40px"
                  TabIndex="2"
                  Text="{Binding Effort, UpdateSourceTrigger=PropertyChanged, StringFormat='{}{##.##}'}"

--- a/src/Idler/Views/ListNotesView.xaml
+++ b/src/Idler/Views/ListNotesView.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Idler"
              mc:Ignorable="d">
     <UserControl.Resources>
-        <CollectionViewSource x:Key="NoteCategoriesList"
+            <CollectionViewSource x:Key="NoteCategoriesList"
                               Source="{Binding Categories}" />
     </UserControl.Resources>
     <Grid Grid.IsSharedSizeScope="True" 
@@ -40,9 +40,15 @@
                                       ItemsSource="{Binding Source={StaticResource NoteCategoriesList}}" 
                                       SelectedValue="{Binding Path=CategoryId}" 
                                       SelectedValuePath="Id" 
-                                      DisplayMemberPath="Name" 
                                       VerticalContentAlignment="Center"
-                                      IsSynchronizedWithCurrentItem="False" />
+                                      IsSynchronizedWithCurrentItem="False"
+                                      ToolTip="{Binding Path=SelectedItem.Name, RelativeSource={RelativeSource Self}}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
                             <GridSplitter Grid.Column="1" 
                                           ResizeDirection="Columns"
                                           HorizontalAlignment="Center" 


### PR DESCRIPTION
### Description of issue

If name of category is longer than width of drop down then part of name is hidden, need to implement tooltip to be able to see full name of it

### Description of fix

- implemented tooltip for both category drop downs: in note and add note views
- implemented ellipsis if name is longer than width of drop down

### Screenshot

![image](https://github.com/sergey-koryshev/idler/assets/11807074/010ae723-2d45-4b39-b7d7-7c1c6aca54a6)
