### PR TITLE
[Bug] Remove button sometimes disappears even when mouse over note row

### DIFF
--- a/src/Idler/Views/ListNotesView.xaml
+++ b/src/Idler/Views/ListNotesView.xaml
@@ -25,7 +25,7 @@
                   Margin="10,5,10,5">
             <ListView.ItemTemplate>
                 <DataTemplate>
-                    <StackPanel Margin="0 1">
+                    <StackPanel Margin="0 1" Background="Transparent">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="{Binding DataContext.CategoryColumnWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" />


### PR DESCRIPTION
### Description of issue

Remove button disappears when mouse is between description input and the button because of the fact that margin between description input and the button doesn't trigger `MouseOver` event

### Description of fix

Added transparent background to the parent `StackPanel` so it fixes issue with `MouseOver` event for margins