### PR TITLE
[bug] Dot cannot be typed in effort input

### DIFF
--- a/src/Idler/Commands/AddNoteCommand.cs
+++ b/src/Idler/Commands/AddNoteCommand.cs
@@ -42,7 +42,7 @@ namespace Idler.Commands
             ShiftNote note = new ShiftNote(this.shift.Notes)
             {
                 CategoryId = addNoteViewModel.CategoryId,
-                Effort = addNoteViewModel.Effort,
+                Effort = addNoteViewModel.Effort ?? 0,
                 Description = addNoteViewModel.Description,
                 StartTime = this.shift.SelectedDate
             };

--- a/src/Idler/Converters/DoubleConverter.cs
+++ b/src/Idler/Converters/DoubleConverter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace Idler.Converters
+{
+    internal class DoubleConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return String.Format("{0:0.##}", value);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string stringifiedValue = value.ToString();
+
+            if (string.IsNullOrWhiteSpace(stringifiedValue))
+            {
+                return new ValidationResult(false, "Value cannot be empty");
+            }
+
+            stringifiedValue = stringifiedValue.Replace(',', '.');
+
+            if (stringifiedValue.StartsWith("."))
+            {
+                stringifiedValue = string.Concat("0", stringifiedValue);
+            }
+
+            if (stringifiedValue.EndsWith("."))
+            {
+                return new ValidationResult(false, "Value cannot end with '.'");
+            }
+
+            try
+            {
+                return decimal.Parse(stringifiedValue, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return new ValidationResult(false, "Value cannot be parsed");
+            }
+        }
+    }
+}

--- a/src/Idler/Idler.csproj
+++ b/src/Idler/Idler.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Commands\CommandBase.cs" />
     <Compile Include="Commands\RemoveNoteCommand.cs" />
     <Compile Include="Commands\SaveShiftCommand.cs" />
+    <Compile Include="Converters\DoubleConverter.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="Helpers\AdvancedTextWriterTraceListener.cs" />
     <Compile Include="Helpers\MVVM\ObservableObject.cs" />

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -103,7 +103,7 @@ namespace Idler
 
                 if (this.AddNoteViewModel is AddNoteViewModel addNoteViewModel)
                 {
-                    result += addNoteViewModel.Effort;
+                    result += addNoteViewModel.Effort ?? 0;
                 }
 
                 return result;

--- a/src/Idler/ViewModels/AddNoteViewModel.cs
+++ b/src/Idler/ViewModels/AddNoteViewModel.cs
@@ -15,7 +15,7 @@ namespace Idler.ViewModels
         private ObservableCollection<NoteCategory> noteCategories;
         private ICollectionView filteredNoteCategories;
         private int categoryId;
-        private decimal effort;
+        private decimal? effort;
         private string description;
         private DateTime startTime;
         private Shift shift;
@@ -62,7 +62,7 @@ namespace Idler.ViewModels
             }
         }
 
-        public decimal Effort
+        public decimal? Effort
         {
             get { return effort; }
             set

--- a/src/Idler/Views/AddNoteView.xaml
+++ b/src/Idler/Views/AddNoteView.xaml
@@ -3,8 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:local="clr-namespace:Idler.Views"
+             xmlns:converters="clr-namespace:Idler.Converters"
              mc:Ignorable="d">
+    <UserControl.Resources>
+        <converters:DoubleConverter x:Key="DoubleConverter" />
+    </UserControl.Resources>
     <DockPanel LastChildFill="True">
         <DockPanel.InputBindings>
             <KeyBinding Key="Enter"
@@ -26,7 +29,7 @@
         </ComboBox>
         <TextBox Width="40px"
                  TabIndex="2"
-                 Text="{Binding Effort, UpdateSourceTrigger=PropertyChanged, StringFormat='{}{##.##}'}"
+                 Text="{Binding Effort, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource DoubleConverter}}"
                  HorizontalContentAlignment="Center"
                  VerticalContentAlignment="Center"
                  Margin="0,0,5,0"

--- a/src/Idler/Views/ListNotesView.xaml
+++ b/src/Idler/Views/ListNotesView.xaml
@@ -3,11 +3,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:converters="clr-namespace:Idler.Converters"
              xmlns:local="clr-namespace:Idler"
              mc:Ignorable="d">
     <UserControl.Resources>
-            <CollectionViewSource x:Key="NoteCategoriesList"
+        <CollectionViewSource x:Key="NoteCategoriesList"
                               Source="{Binding Categories}" />
+        <converters:DoubleConverter x:Key="DoubleConverter" />
     </UserControl.Resources>
     <Grid Grid.IsSharedSizeScope="True" 
           Background="WhiteSmoke">
@@ -56,7 +58,7 @@
                                           Focusable="False"
                                           Width="2" />
                             <TextBox Grid.Column="2" 
-                                     Text="{Binding Path=Effort, UpdateSourceTrigger=PropertyChanged}" 
+                                     Text="{Binding Path=Effort, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource DoubleConverter}}" 
                                      Padding="3" 
                                      HorizontalContentAlignment="Center" />
                             <GridSplitter Grid.Column="3" 


### PR DESCRIPTION
### Description of issue

Dot cannot be typed in effort input within list notes due to binding issues. Since number cannot end with `.` sign (because it cannot be casted to `decimal` type), standard behaviour of `TextBox` doesn't allow the sign in the end of number.

### Description of fix

The issue could be fixed by changing `UpdateSourceTrigger` to `LostFocus` but it would bring regression to user experience. So I implemented `DoubleConverter` to manage a process of parsing entering number. Except fixing the issue, it also bring new feature: now the input can take both decimal symbols `.` and `,`, and parse entering number to decimal value correctly. 

Related issue: #56 