### PR TITLE
Button "Refresh" must be active to give ability to reset changes

### DIFF
--- a/src/Idler/Commands/RefreshNotesCommand.cs
+++ b/src/Idler/Commands/RefreshNotesCommand.cs
@@ -1,19 +1,17 @@
-﻿using Idler.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using Idler.Components;
+using Idler.Components.PopupDialogControl;
+using Idler.Extensions;
 
 namespace Idler.Commands
 {
     public class RefreshNotesCommand : CommandBase
     {
         private Shift shift;
+        private PopupDialogHost dialogHost;
 
-        public RefreshNotesCommand(Shift shift) {
+        public RefreshNotesCommand(Shift shift, PopupDialogHost dialogHost) {
             this.shift = shift;
+            this.dialogHost = dialogHost;
         }
         public override void Execute(object parameter)
         {
@@ -21,10 +19,10 @@ namespace Idler.Commands
 
             if (this.shift.Changed)
             {
-                canRefresh = MessageBox.Show(
-                    "There are unsaved changes, are you sure you want to refresh without saving?",
+                canRefresh = this.dialogHost.ShowDialog(
                     "Warning",
-                    MessageBoxButton.OKCancel) == MessageBoxResult.OK;
+                    "There are unsaved changes, are you sure you want to refresh without saving?",
+                    Buttons.OkCancel) == Result.OK;
             }
 
             if (canRefresh)

--- a/src/Idler/Commands/RefreshNotesCommand.cs
+++ b/src/Idler/Commands/RefreshNotesCommand.cs
@@ -1,0 +1,36 @@
+﻿using Idler.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Idler.Commands
+{
+    public class RefreshNotesCommand : CommandBase
+    {
+        private Shift shift;
+
+        public RefreshNotesCommand(Shift shift) {
+            this.shift = shift;
+        }
+        public override void Execute(object parameter)
+        {
+            bool canRefresh = true;
+
+            if (this.shift.Changed)
+            {
+                canRefresh = MessageBox.Show(
+                    "There are unsaved changes, are you sure you want to refresh without saving?",
+                    "Warning",
+                    MessageBoxButton.OKCancel) == MessageBoxResult.OK;
+            }
+
+            if (canRefresh)
+            {
+                this.shift.RefreshAsync().SafeFireAndForget();
+            }
+        }
+    }
+}

--- a/src/Idler/Components/PopupDialogControl/Buttons.cs
+++ b/src/Idler/Components/PopupDialogControl/Buttons.cs
@@ -1,0 +1,7 @@
+﻿namespace Idler.Components.PopupDialogControl
+{
+    public enum Buttons
+    {
+        OkCancel
+    }
+}

--- a/src/Idler/Components/PopupDialogControl/Commands.cs
+++ b/src/Idler/Components/PopupDialogControl/Commands.cs
@@ -1,0 +1,31 @@
+﻿using Idler.Commands;
+
+namespace Idler.Components.PopupDialogControl
+{
+    public class OkCommand : CommandBase
+    {
+        private PopupDialog popupDialog;
+        public OkCommand(PopupDialog popupDialog) { 
+            this.popupDialog = popupDialog;
+        }
+
+        public override void Execute(object parameter)
+        {
+            this.popupDialog.Result = Result.OK;
+        }
+    }
+
+    public class CancelCommand : CommandBase
+    {
+        private PopupDialog popupDialog;
+        public CancelCommand(PopupDialog popupDialog)
+        {
+            this.popupDialog = popupDialog;
+        }
+
+        public override void Execute(object parameter)
+        {
+            this.popupDialog.Result = Result.Cancel;
+        }
+    }
+}

--- a/src/Idler/Components/PopupDialogControl/PopupDialog.cs
+++ b/src/Idler/Components/PopupDialogControl/PopupDialog.cs
@@ -1,0 +1,75 @@
+﻿using Idler.Components.PopupDialogControl;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Idler.Components
+{
+    public class PopupDialog : Control
+    {
+        public static readonly DependencyProperty TitleProperty =
+            DependencyProperty.Register("Title", typeof(string), typeof(PopupDialog), new PropertyMetadata(string.Empty));
+
+        public static readonly DependencyProperty MessageProperty =
+            DependencyProperty.Register("Message", typeof(string), typeof(PopupDialog), new PropertyMetadata(string.Empty));
+
+        public static readonly DependencyProperty ButtonsProperty =
+            DependencyProperty.Register("Buttons", typeof(Buttons), typeof(PopupDialog), new PropertyMetadata(Buttons.OkCancel));
+
+        public static readonly DependencyProperty ResultProperty =
+            DependencyProperty.Register("Result", typeof(Result), typeof(PopupDialog), new PropertyMetadata(Result.None));
+
+        public static readonly DependencyProperty OkCommandProperty =
+            DependencyProperty.Register("OkCommand", typeof(ICommand), typeof(PopupDialog), new PropertyMetadata(null));
+
+        public static readonly DependencyProperty CancelCommandProperty =
+            DependencyProperty.Register("CancelCommand", typeof(ICommand), typeof(PopupDialog), new PropertyMetadata(null));
+
+        public string Title
+        {
+            get { return (string)GetValue(TitleProperty); }
+            set { SetValue(TitleProperty, value); }
+        }
+
+        public string Message
+        {
+            get { return (string)GetValue(MessageProperty); }
+            set { SetValue(MessageProperty, value); }
+        }
+
+        public Buttons Buttons
+        {
+            get { return (Buttons)GetValue(ButtonsProperty); }
+            set { SetValue(ButtonsProperty, value); }
+        }
+
+        public Result Result
+        {
+            get { return (Result)GetValue(ResultProperty); }
+            set { SetValue(ResultProperty, value); }
+        }
+
+        public ICommand OkCommand
+        {
+            get { return (ICommand)GetValue(OkCommandProperty); }
+            set { SetValue(OkCommandProperty, value); }
+        }
+
+        public ICommand CancelCommand
+        {
+            get { return (ICommand)GetValue(CancelCommandProperty); }
+            set { SetValue(CancelCommandProperty, value); }
+        }
+
+        static PopupDialog()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(PopupDialog), new FrameworkPropertyMetadata(typeof(PopupDialog)));
+        }
+
+        public PopupDialog()
+        {
+            this.OkCommand = new OkCommand(this);
+            this.CancelCommand = new CancelCommand(this);
+        }
+    }
+}

--- a/src/Idler/Components/PopupDialogControl/Result.cs
+++ b/src/Idler/Components/PopupDialogControl/Result.cs
@@ -1,0 +1,9 @@
+﻿namespace Idler.Components.PopupDialogControl
+{
+    public enum Result
+    {
+        None,
+        OK,
+        Cancel
+    }
+}

--- a/src/Idler/Components/PopupDialogControl/Style.xaml
+++ b/src/Idler/Components/PopupDialogControl/Style.xaml
@@ -6,11 +6,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type components:PopupDialog}">
                     <Grid>
-                        <DockPanel Background="Black" Opacity="0.5">
-                            <DockPanel.BitmapEffect>
-                                <BlurBitmapEffect Radius="5" />
-                            </DockPanel.BitmapEffect>
-                        </DockPanel>
+                        <DockPanel Background="Black" Opacity="0.3" />
                         <DockPanel>
                             <Border Background="White"
                                 BorderBrush="{TemplateBinding BorderBrush}"

--- a/src/Idler/Components/PopupDialogControl/Style.xaml
+++ b/src/Idler/Components/PopupDialogControl/Style.xaml
@@ -1,0 +1,80 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:components="clr-namespace:Idler.Components">
+    <Style TargetType="{x:Type components:PopupDialog}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type components:PopupDialog}">
+                    <Grid>
+                        <DockPanel Background="Black" Opacity="0.5">
+                            <DockPanel.BitmapEffect>
+                                <BlurBitmapEffect Radius="5" />
+                            </DockPanel.BitmapEffect>
+                        </DockPanel>
+                        <DockPanel>
+                            <Border Background="White"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="5"
+                                MaxWidth="300" 
+                                VerticalAlignment="Center"
+                                Padding="25,25,25,15">
+                                <StackPanel 
+                                Orientation="Vertical" 
+                                HorizontalAlignment="Center" 
+                                VerticalAlignment="Center">
+                                    <TextBlock 
+                                    Grid.Row="0" 
+                                    Text="{TemplateBinding Title}" 
+                                    HorizontalAlignment="Center" 
+                                    FontSize="20" 
+                                    FontWeight="Bold" />
+                                    <TextBlock 
+                                    Grid.Row="1"
+                                    Text="{TemplateBinding Message}" 
+                                    HorizontalAlignment="Center" 
+                                    TextAlignment="Center" 
+                                    TextWrapping="Wrap" Margin="0,15,0,25" />
+                                    <StackPanel 
+                                    Grid.Row="2" 
+                                    Orientation="Horizontal"
+                                    HorizontalAlignment="Center">
+                                        <Button Content="Ok"
+                                            Padding="25,5"
+                                            Margin="0,0,15,0"
+                                            Command="{TemplateBinding OkCommand}">
+                                            <Button.Style>
+                                                <Style TargetType="Button">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Buttons, RelativeSource={RelativeSource AncestorType=components:PopupDialog}}" Value="OkCancel">
+                                                            <Setter Property="Visibility" Value="Visible" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Button.Style>
+                                        </Button>
+                                        <Button Content="Cancel"
+                                            Padding="25,5"
+                                            Command="{TemplateBinding CancelCommand}">
+                                            <Button.Style>
+                                                <Style TargetType="Button">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Buttons, RelativeSource={RelativeSource AncestorType=components:PopupDialog}}" Value="OkCancel">
+                                                            <Setter Property="Visibility" Value="Visible" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Button.Style>
+                                        </Button>
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </DockPanel>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/Idler/Components/PopupDialogHostControl/PopupDialogHost.cs
+++ b/src/Idler/Components/PopupDialogHostControl/PopupDialogHost.cs
@@ -1,0 +1,46 @@
+﻿using Idler.Components.PopupDialogControl;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace Idler.Components
+{
+    public class PopupDialogHost : ContentControl
+    {
+        static PopupDialogHost()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(PopupDialogHost), new FrameworkPropertyMetadata(typeof(PopupDialogHost)));
+        }
+
+        public Result ShowDialog(string title, string message, Buttons buttons)
+        {
+            PopupDialog popupDialog = new PopupDialog()
+            {
+                Title = title,
+                Message = message,
+                Buttons = buttons
+            };
+
+            var oldContent = this.Content;
+            this.Content = popupDialog;
+
+            while (popupDialog.Result == Result.None)
+            {
+                if (Dispatcher.HasShutdownStarted ||
+                Dispatcher.HasShutdownFinished)
+                {
+                    break;
+                }
+
+                Dispatcher.Invoke(
+                    DispatcherPriority.Background,
+                    new ThreadStart(delegate { }));
+                Thread.Sleep(20);
+            }
+
+            this.Content = oldContent;
+            return popupDialog.Result;
+        }
+    }
+}

--- a/src/Idler/Components/PopupDialogHostControl/Style.xaml
+++ b/src/Idler/Components/PopupDialogHostControl/Style.xaml
@@ -1,0 +1,19 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:components="clr-namespace:Idler.Components">
+    <Style TargetType="{x:Type components:PopupDialogHost}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type components:PopupDialogHost}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          Margin="{TemplateBinding Padding}"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
+</ResourceDictionary>

--- a/src/Idler/Idler.csproj
+++ b/src/Idler/Idler.csproj
@@ -103,6 +103,7 @@
     </Compile>
     <Compile Include="Commands\AddNoteCommand.cs" />
     <Compile Include="Commands\CommandBase.cs" />
+    <Compile Include="Commands\RefreshNotesCommand.cs" />
     <Compile Include="Commands\RemoveNoteCommand.cs" />
     <Compile Include="Commands\SaveShiftCommand.cs" />
     <Compile Include="Converters\DoubleConverter.cs" />

--- a/src/Idler/Idler.csproj
+++ b/src/Idler/Idler.csproj
@@ -106,6 +106,11 @@
     <Compile Include="Commands\RefreshNotesCommand.cs" />
     <Compile Include="Commands\RemoveNoteCommand.cs" />
     <Compile Include="Commands\SaveShiftCommand.cs" />
+    <Compile Include="Components\PopupDialogControl\Commands.cs" />
+    <Compile Include="Components\PopupDialogControl\PopupDialog.cs" />
+    <Compile Include="Components\PopupDialogControl\Buttons.cs" />
+    <Compile Include="Components\PopupDialogControl\Result.cs" />
+    <Compile Include="Components\PopupDialogHostControl\PopupDialogHost.cs" />
     <Compile Include="Converters\DoubleConverter.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="Helpers\AdvancedTextWriterTraceListener.cs" />
@@ -131,6 +136,14 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Components\PopupDialogControl\Style.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Components\PopupDialogHostControl\Style.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -147,6 +160,10 @@
     <Page Include="SettingsWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Themes\Generic.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\AddNoteView.xaml">
       <SubType>Designer</SubType>

--- a/src/Idler/MainWindow.xaml
+++ b/src/Idler/MainWindow.xaml
@@ -87,25 +87,10 @@
                             </Style>
                         </Button.Style>
                     </Button>
-                    <Button x:Name="btnRefresh"
-                            Content="Refresh"
+                    <Button Content="Refresh"
                             DockPanel.Dock="Right"
                             Padding="25,5"
-                            Click="BtnRefresh_Click">
-                        <Button.Style>
-                            <Style TargetType="Button">
-                                <Setter Property="IsEnabled"
-                                        Value="True" />
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding CurrentShift.Changed}"
-                                                 Value="True">
-                                        <Setter Property="IsEnabled"
-                                                Value="False" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
-                    </Button>
+                            Command="{Binding RefreshNotesCommand}" />
                     <Button x:Name="btnSave"
                             Content="Save Changes"
                             ToolTip="Ctrl+S"

--- a/src/Idler/MainWindow.xaml
+++ b/src/Idler/MainWindow.xaml
@@ -59,6 +59,7 @@
                     </Style>
                 </DockPanel.Style>
             </DockPanel>
+            <ContentControl Content="{Binding DialogHost}" />
             <Grid Panel.ZIndex="-1">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="auto" />

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Idler.Commands;
+using Idler.Components;
 using Idler.ViewModels;
 using System;
 using System.Collections.ObjectModel;
@@ -27,6 +28,7 @@ namespace Idler
         private Shift currentShift;
         private ListNotesViewModel listNotesViewModel;
         private ICommand refreshNotesCommand;
+        private PopupDialogHost dialogHost;
 
         public AddNoteViewModel AddNoteViewModel
         {
@@ -139,6 +141,15 @@ namespace Idler
             }
         }
 
+        public PopupDialogHost DialogHost
+        {
+            get => dialogHost;
+            set { 
+                dialogHost = value;
+                this.OnPropertyChanged(nameof(this.DialogHost));
+            }
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         public MainWindow()
@@ -167,6 +178,8 @@ namespace Idler
                     Trace.TraceError($"Error has been occurred during initial loading notes: {action.Exception}");
                 }
             });
+
+            this.DialogHost = new PopupDialogHost();
         }
 
         private void NoteCategoriesUpdateComletedHandler(object sender, EventArgs e)
@@ -199,13 +212,16 @@ namespace Idler
                     this.AddNoteViewModel.Shift = this.CurrentShift;
                     this.CurrentShift.PropertyChanged += CurrentShiftPropertyChanged;
                     this.SaveShiftCommand = new SaveShiftCommand(this, this.CurrentShift);
-                    this.RefreshNotesCommand = new RefreshNotesCommand(this.CurrentShift);
+                    this.RefreshNotesCommand = new RefreshNotesCommand(this.CurrentShift, this.DialogHost);
                     break;
                 case nameof(this.ListNotesViewModel):
                     this.AddNoteViewModel.ListNotesViewModel = this.ListNotesViewModel;
                     break;
                 case nameof(this.NoteCategories):
                     this.AddNoteViewModel.NoteCategories = this.NoteCategories.Categories;
+                    break;
+                case nameof(DialogHost):
+                    this.RefreshNotesCommand = new RefreshNotesCommand(this.CurrentShift, this.DialogHost);
                     break;
                 case nameof(this.SelectedDate):
                     Properties.Settings.Default.SelectedDate = this.SelectedDate;

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -26,6 +26,7 @@ namespace Idler
         private ICommand saveShiftCommand;
         private Shift currentShift;
         private ListNotesViewModel listNotesViewModel;
+        private ICommand refreshNotesCommand;
 
         public AddNoteViewModel AddNoteViewModel
         {
@@ -128,6 +129,16 @@ namespace Idler
             }
         }
 
+        public ICommand RefreshNotesCommand
+        {
+            get => refreshNotesCommand;
+            set
+            {
+                refreshNotesCommand = value;
+                this.OnPropertyChanged(nameof(this.RefreshNotesCommand));
+            }
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         public MainWindow()
@@ -188,6 +199,7 @@ namespace Idler
                     this.AddNoteViewModel.Shift = this.CurrentShift;
                     this.CurrentShift.PropertyChanged += CurrentShiftPropertyChanged;
                     this.SaveShiftCommand = new SaveShiftCommand(this, this.CurrentShift);
+                    this.RefreshNotesCommand = new RefreshNotesCommand(this.CurrentShift);
                     break;
                 case nameof(this.ListNotesViewModel):
                     this.AddNoteViewModel.ListNotesViewModel = this.ListNotesViewModel;
@@ -226,11 +238,6 @@ namespace Idler
         public void OnPropertyChanged(string propertyName)
         {
             this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        private async void BtnRefresh_Click(object sender, RoutedEventArgs e)
-        {
-            await this.CurrentShift.RefreshAsync();
         }
 
         private void BtnNextShift_Click(object sender, RoutedEventArgs e)

--- a/src/Idler/Themes/Generic.xaml
+++ b/src/Idler/Themes/Generic.xaml
@@ -1,0 +1,9 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="/Idler;component/Components/PopupDialogControl/Style.xaml"/>
+        <ResourceDictionary Source="/Idler;component/Components/PopupDialogHostControl/Style.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary>


### PR DESCRIPTION
### Description of issue

Button `Refresh` must give ability to reset changes but it becomes inactive when user makes changes. Need to remove logic to disable the button and introduce confirmation dialog if there are unsaved changes

### Description of fix

- implemented new custom components
  - `PopupDialog` - represents popup dialog which takes 3 parameters: `Title`, `Message` and `Buttons`
  - `PopupDialogHost` - container to show popup dialog within. It contains method `ShowDialog` which creates new `PopupDialog` with provided parameters and put it inside `PopupDialogHost` component. Waiting for pressing buttons in dialogs was implemented via small hack to "freeze" thread. Need to keep in mind that potentially it can harm performance
- implemented `PopupDialogHost` in main window
- added command to refresh notes to show confirmation dialog if there are unsaved changes

### Screenshot 
![image](https://github.com/sergey-koryshev/idler/assets/11807074/e3e24550-34ac-4f35-b8d0-0d241ff2f11c)