### PR TITLE
Notes lost sharpness

### DIFF
--- a/src/Idler/Views/ListNotesView.xaml
+++ b/src/Idler/Views/ListNotesView.xaml
@@ -13,35 +13,41 @@
         <Style x:Key="BlurredTextBox" TargetType="{x:Type TextBox}">
             <Style.Resources>
                 <Style TargetType="{x:Type ScrollViewer}">
-                    <Setter Property="ContentPresenter.Effect">
-                        <Setter.Value>
-                            <BlurEffect Radius="7"></BlurEffect>
-                        </Setter.Value>
-                    </Setter>
+                    <Setter Property="ContentPresenter.Effect" Value="{x:Null}" />
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding DataContext.AreNotesBlurred, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="False">
-                            <Setter Property="ContentPresenter.Effect" Value="{x:Null}" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding IsFocused, RelativeSource={RelativeSource AncestorType=TextBox}}" Value="True">
-                            <Setter Property="ContentPresenter.Effect" Value="{x:Null}" />
-                        </DataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding DataContext.AreNotesBlurred, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="True" />
+                                <Condition Binding="{Binding IsFocused, RelativeSource={RelativeSource AncestorType=TextBox}}" Value="False" />
+                            </MultiDataTrigger.Conditions>
+                            <MultiDataTrigger.Setters>
+                                <Setter Property="ContentPresenter.Effect">
+                                    <Setter.Value>
+                                        <BlurEffect Radius="10" />
+                                    </Setter.Value>
+                                </Setter>
+                            </MultiDataTrigger.Setters>
+                        </MultiDataTrigger>
                     </Style.Triggers>
                 </Style>
             </Style.Resources>
         </Style>
         <Style x:Key="BlurredTextBlock" TargetType="TextBlock">
-            <Setter Property="ContentPresenter.Effect">
-                <Setter.Value>
-                    <BlurEffect Radius="7"></BlurEffect>
-                </Setter.Value>
-            </Setter>
+            <Setter Property="ContentPresenter.Effect" Value="{x:Null}" />
             <Style.Triggers>
-                <DataTrigger Binding="{Binding DataContext.AreNotesBlurred, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="False">
-                    <Setter Property="ContentPresenter.Effect" Value="{x:Null}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding IsFocused, RelativeSource={RelativeSource AncestorType=ComboBox}}" Value="True">
-                    <Setter Property="ContentPresenter.Effect" Value="{x:Null}" />
-                </DataTrigger>
+                <MultiDataTrigger>
+                    <MultiDataTrigger.Conditions>
+                        <Condition Binding="{Binding DataContext.AreNotesBlurred, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="True" />
+                        <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=ComboBox}}" Value="False" />
+                    </MultiDataTrigger.Conditions>
+                    <MultiDataTrigger.Setters>
+                        <Setter Property="ContentPresenter.Effect">
+                            <Setter.Value>
+                                <BlurEffect Radius="10" />
+                            </Setter.Value>
+                        </Setter>
+                    </MultiDataTrigger.Setters>
+                </MultiDataTrigger>
             </Style.Triggers>
         </Style>
     </UserControl.Resources>

--- a/src/Idler/Views/ListNotesView.xaml
+++ b/src/Idler/Views/ListNotesView.xaml
@@ -20,18 +20,10 @@
                     </Setter>
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding DataContext.AreNotesBlurred, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="False">
-                            <Setter Property="ContentPresenter.Effect">
-                                <Setter.Value>
-                                    <BlurEffect Radius="0"></BlurEffect>
-                                </Setter.Value>
-                            </Setter>
+                            <Setter Property="ContentPresenter.Effect" Value="{x:Null}" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding IsFocused, RelativeSource={RelativeSource AncestorType=TextBox}}" Value="True">
-                            <Setter Property="ContentPresenter.Effect">
-                                <Setter.Value>
-                                    <BlurEffect Radius="0"></BlurEffect>
-                                </Setter.Value>
-                            </Setter>
+                            <Setter Property="ContentPresenter.Effect" Value="{x:Null}" />
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
@@ -45,18 +37,10 @@
             </Setter>
             <Style.Triggers>
                 <DataTrigger Binding="{Binding DataContext.AreNotesBlurred, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="False">
-                    <Setter Property="ContentPresenter.Effect">
-                        <Setter.Value>
-                            <BlurEffect Radius="0"></BlurEffect>
-                        </Setter.Value>
-                    </Setter>
+                    <Setter Property="ContentPresenter.Effect" Value="{x:Null}" />
                 </DataTrigger>
                 <DataTrigger Binding="{Binding IsFocused, RelativeSource={RelativeSource AncestorType=ComboBox}}" Value="True">
-                    <Setter Property="ContentPresenter.Effect">
-                        <Setter.Value>
-                            <BlurEffect Radius="0"></BlurEffect>
-                        </Setter.Value>
-                    </Setter>
+                    <Setter Property="ContentPresenter.Effect" Value="{x:Null}" />
                 </DataTrigger>
             </Style.Triggers>
         </Style>


### PR DESCRIPTION
### Description of issue

Notes related text boxes lost sharpness when they are not blurred due to the fact that when `Radius` of `BlurEffect` equals to `0` then it seems still blurred despite zero-value. I didn't found information related this so probably it can be considered as WPF related bug

### Description of fix

I fixed it by removing `BlurEffect` for not blurred elements. It works as expected but as far as I understand if we decide to implement some animation for blur action we will have some problems with such approach