### PR TITLE
Remove version from main window title

### DIFF
--- a/src/Idler/About.xaml.cs
+++ b/src/Idler/About.xaml.cs
@@ -1,19 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace Idler
 {
@@ -46,9 +35,9 @@ namespace Idler
 
         public About()
         {
-            var appVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+            var appVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
             this.Version = $"({appVersion})";
-            this.Copyright = $"Copyright (C) {DateTime.Now.Year}  Sergey Koryshev";
+            this.Copyright = $"Copyright (C) 2020-{DateTime.Now.Year}  Sergey Koryshev";
             InitializeComponent();
         }
 

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -166,11 +166,7 @@ namespace Idler
         public MainWindow()
         {
             Trace.TraceInformation("Initializing main window");
-
-            var fileVersionInfo = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
-            var version = fileVersionInfo.ProductVersion;
-            this.fullAppVersion = fileVersionInfo.FileVersion;
-            this.FullAppName = $"{appName} ({version})";
+            this.FullAppName = $"{appName}";
 
             InitializeComponent();
 


### PR DESCRIPTION
### Description of issue

Need to remove version from Main Window's title

### Description of fix

- removed version from Main Window's title
- make window `About` show all 4 numbers of version
- changed copyright line