### PR TITLE
Button Save on Settings window must be activated only if there are changes in settings

### DIFF
--- a/src/Idler/App.xaml
+++ b/src/Idler/App.xaml
@@ -4,6 +4,11 @@
              xmlns:local="clr-namespace:Idler"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-         
+        <!-- Fixes bug with binding in ComboBox. 
+        https://stackoverflow.com/questions/47391020/cannot-find-source-for-binding-with-reference-relativesource-findancestor -->
+        <Style TargetType="{x:Type ComboBoxItem}">
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="VerticalContentAlignment" Value="Top" />
+        </Style>
     </Application.Resources>
 </Application>

--- a/src/Idler/Helpers/MVVM/ObservableObject.cs
+++ b/src/Idler/Helpers/MVVM/ObservableObject.cs
@@ -39,7 +39,7 @@ namespace Idler.Helpers.MVVM
         /// Notifies subscribers that specified property has been changed
         /// </summary>
         /// <param name="propertyName">Name of property</param>
-        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = "")
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = "", bool skipChange = false)
         {
             this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
             Trace.TraceInformation($"Property '{propertyName}' has been changed to value '{this.GetType().GetProperty(propertyName).GetValue(this)}'");
@@ -50,7 +50,7 @@ namespace Idler.Helpers.MVVM
                 case nameof(this.Changed):
                     break;
                 default:
-                    this.Changed = true;
+                    this.Changed = !skipChange && true;
                     break;
             }
         }

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -173,7 +173,8 @@ namespace Idler
             this.PropertyChanged += MainWindowPropertyChangedHandler;
 
             this.NoteCategories = new NoteCategories();
-            this.NoteCategories.UpdateCompleted += NoteCategoriesUpdateComletedHandler;
+            this.NoteCategories.UpdateCompleted += NoteCategoriesUpdateOrRefreshComletedHandler;
+            this.NoteCategories.RefreshCompleted += NoteCategoriesUpdateOrRefreshComletedHandler;
 
             this.isBusy = true;
 
@@ -190,9 +191,10 @@ namespace Idler
             this.ExportNotesCommand = new RelayCommand(ExportNotesCommandHandler);
         }
 
-        private void NoteCategoriesUpdateComletedHandler(object sender, EventArgs e)
+        private void NoteCategoriesUpdateOrRefreshComletedHandler(object sender, EventArgs e)
         {
             this.AddNoteViewModel?.RefreshFilteredNoteCategoriesView();
+            this.ListNotesViewModel?.ReInstanceCategoryIds();
         }
 
         private async Task InitialLoadingShiftNotes(ObservableCollection<NoteCategory> categories)

--- a/src/Idler/NoteCategories.cs
+++ b/src/Idler/NoteCategories.cs
@@ -56,9 +56,9 @@ namespace Idler
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    foreach (NoteCategory newShiftNote in e.NewItems)
+                    foreach (NoteCategory noteCategory in e.NewItems)
                     {
-                        newShiftNote.PropertyChanged += CategoryPropertyChangedHandler;
+                        noteCategory.PropertyChanged += CategoryPropertyChangedHandler;
                     }
                     break;
             }
@@ -100,10 +100,7 @@ namespace Idler
             switch (e.PropertyName)
             {
                 case nameof(NoteCategory.Changed):
-                    if (this.Changed != true)
-                    {
-                        this.Changed = ((NoteCategory)sender).Changed;
-                    }
+                    this.Changed = ((NoteCategory)sender).Changed;
                     break;
             }
         }

--- a/src/Idler/NoteCategories.cs
+++ b/src/Idler/NoteCategories.cs
@@ -1,8 +1,6 @@
 ﻿using Idler.Helpers.DB;
 using Idler.Helpers.MVVM;
-using Idler.Interfaces;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -69,6 +67,8 @@ namespace Idler
         /// </summary>
         public override async Task RefreshAsync()
         {
+            OnRefreshStarted();
+
             DataTable categoriesTable = await NoteCategories.GetCategories();
 
             this.Categories.Clear();
@@ -93,6 +93,8 @@ namespace Idler
                     Trace.TraceError($"Error has occurred while creating new NoteCategory object (Id: {category[NoteCategories.idFieldName]}, Name: {category[NoteCategories.nameFieldName]}, Hidden: {category[NoteCategories.hiddenFieldName]}): {ex}");
                 }
             }
+
+            OnRefreshCompleted();
         }
 
         private void CategoryPropertyChangedHandler(object sender, PropertyChangedEventArgs e)

--- a/src/Idler/NoteCategory.cs
+++ b/src/Idler/NoteCategory.cs
@@ -74,7 +74,7 @@ namespace Idler
         /// Creates category without Id
         /// </summary>
         /// <param name="name">name of category</param>
-        /// <param name="hidden">determines if the catogory is hidden</param>
+        /// <param name="hidden">determines if the category is hidden</param>
         public NoteCategory(string name, bool hidden)
         {
             this.Id = null;
@@ -84,7 +84,7 @@ namespace Idler
 
         public override string ToString()
         {
-            return $"Note Category '{this.Name}' (#{this.Id}, hidded: {this.Hidden})";
+            return $"Note Category '{this.Name}' (#{this.Id}, hidden: {this.Hidden})";
         }
     }
 }

--- a/src/Idler/SettingsWindow.xaml
+++ b/src/Idler/SettingsWindow.xaml
@@ -104,8 +104,8 @@
             </DataGrid.RowStyle>
         </DataGrid>
         <DockPanel Grid.Row="12" Grid.ColumnSpan="3" LastChildFill="False">
-            <Button x:Name="btnReset" Content="Reset" Padding="25,5" DockPanel.Dock="Right" Click="btnReset_Click" Height="28" VerticalAlignment="Bottom" />
-            <Button x:Name="btnSave" Content="Save" Padding="25,5" DockPanel.Dock="Right" Margin="0,0,5,0" Click="btnSave_Click"/>
+            <Button x:Name="btnReset" Content="Reset" Padding="25,5" DockPanel.Dock="Right" Click="btnReset_Click" Height="28" VerticalAlignment="Bottom" IsEnabled="{Binding AreSettingsUnsaved}" />
+            <Button x:Name="btnSave" Content="Save" Padding="25,5" DockPanel.Dock="Right" Margin="0,0,5,0" Click="btnSave_Click" IsEnabled="{Binding AreSettingsUnsaved}"/>
             <Button x:Name="btnDefault" Content="Return to default" Padding="25,5" DockPanel.Dock="Right" Margin="0,0,5,0" Click="btnDefault_Click"/>
         </DockPanel>
     </Grid>

--- a/src/Idler/ShiftNote.cs
+++ b/src/Idler/ShiftNote.cs
@@ -241,5 +241,10 @@ WHERE {ShiftNote.idFieldName} = ?";
         {
             return $"Shift Note '{this.Description}' ({this.Effort})";
         }
+
+        public void ReInstanceCategoryId()
+        {
+            this.OnPropertyChanged(nameof(this.CategoryId), true);
+        }
     }
 }

--- a/src/Idler/ViewModels/AddNoteViewModel.cs
+++ b/src/Idler/ViewModels/AddNoteViewModel.cs
@@ -180,6 +180,11 @@ namespace Idler.ViewModels
         public void RefreshFilteredNoteCategoriesView()
         {
             this.FilteredNoteCategories.Refresh();
+
+            // we need to trigger event PropertyChanged due to 
+            // the ComboBox loses value of selected item because of
+            // validation error when list of categories are cleared
+            this.OnPropertyChanged(nameof(this.CategoryId));
         }
     }
 }

--- a/src/Idler/ViewModels/ListNotesViewModel.cs
+++ b/src/Idler/ViewModels/ListNotesViewModel.cs
@@ -65,10 +65,9 @@ namespace Idler.ViewModels
             }
         }
 
-        private Boolean IsAutoBlurEnabled
+        private bool IsAutoBlurEnabled
         {
-            get =>
-                Properties.Settings.Default.AutoBlurInterval.Ticks > 0 &&
+            get => Properties.Settings.Default.AutoBlurInterval.Ticks > 0 &&
                 Properties.Settings.Default.IsAutoBlurEnabled;
         }
 
@@ -136,6 +135,18 @@ namespace Idler.ViewModels
         {
             this.autoBlurTimer.Stop();
             this.ManageAutoBlurTimer();
+        }
+
+        /// <summary>
+        /// Fixes binding category Id in ComboBox when list of categories are refreshed
+        /// since ComboBox doesn't do it by itself
+        /// </summary>
+        public void ReInstanceCategoryIds()
+        {
+            foreach (var item in Notes)
+            {
+                item.ReInstanceCategoryId();
+            }
         }
     }
 }


### PR DESCRIPTION
### Description of issue

Buttons `Save` and `Reset` are active always but they need to be active only if user made some changes there

### Description of fix

- implemented logic to enable buttons only if there are changes in settings/notes
- fixed bug when category disappears from list notes and dropdown in adding note area if user click button `Reset`. The issue occurs due to strange behaviour of `ComboBox` component. I had to implement logic to send addition event `PropertyChange` on each `CategoryId` to fix binding.
- removed odd binding errors for `ComboBox` by setting properties `HorizontalContentAlignment` and `VerticalContentAlignment` explicitly in `App.xaml`