### PR TITLE
Link to help is broken

### DIFF
--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -167,7 +167,7 @@ namespace Idler
         {
             Trace.TraceInformation("Initializing main window");
             this.FullAppName = $"{appName}";
-
+            this.fullAppVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
             InitializeComponent();
 
             this.PropertyChanged += MainWindowPropertyChangedHandler;


### PR DESCRIPTION
### Description of issue

The link to help is broken due to logic to get version was mistakenly removed

### Description of fix

Restored value for field `fullAppVersion`