### PR TITLE
If user set date manually then duplicated notes are displayed

### DIFF
--- a/src/Idler/Shift.cs
+++ b/src/Idler/Shift.cs
@@ -127,6 +127,11 @@ namespace Idler
         /// </summary>
         public override async Task RefreshAsync()
         {
+            if (this.IsRefreshing == true)
+            {
+                return;
+            }
+
             this.OnRefreshStarted();
 
             this.Notes.Clear();


### PR DESCRIPTION
### Description of issue

If user sets date manually then duplicated notes are loaded. This happens because data picker element fires property changed event two times: by `DatePicker` and by `Calendar`.

### Description of fix

I added check if there is ongoing refresh task and jus skip refreshing in this case.