### PR TITLE
Save position and size of main window and restore it after app restart

### DIFF
--- a/src/Idler/App.config
+++ b/src/Idler/App.config
@@ -53,6 +53,21 @@
       <setting name="SkipWeekends" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="MainWindowHeight" serializeAs="String">
+        <value>450</value>
+      </setting>
+      <setting name="MainWindowWidth" serializeAs="String">
+        <value>800</value>
+      </setting>
+      <setting name="MainWindowLeft" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="MainWindowTop" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="MainWindowMaximized" serializeAs="String">
+        <value>False</value>
+      </setting>
     </Idler.Properties.Settings>
   </userSettings>
 </configuration>

--- a/src/Idler/MainWindow.xaml
+++ b/src/Idler/MainWindow.xaml
@@ -8,8 +8,6 @@
         mc:Ignorable="d"
         DataContext="{Binding RelativeSource={RelativeSource Self}}"
         Title="{Binding FullAppName}"
-        Height="450"
-        Width="800"
         ResizeMode="CanResizeWithGrip">
     <Window.Resources>
         <CollectionViewSource x:Key="NoteCategoriesList"

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -181,6 +181,7 @@ namespace Idler
             Trace.TraceInformation("Initializing main window");
             this.FullAppName = $"{appName}";
             this.fullAppVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
+            this.RestoreWindowPosition();
             InitializeComponent();
 
             this.Closing += WindowClosingHandler;
@@ -199,6 +200,11 @@ namespace Idler
         private void WindowClosingHandler(object sender, CancelEventArgs e)
         {
             e.Cancel = !this.CanApplicationBeClosed();
+
+            if (!e.Cancel)
+            {
+                this.SaveWindowPosition();
+            }
         }
 
         private void NoteCategoriesUpdateOrRefreshComletedHandler(object sender, EventArgs e)
@@ -356,6 +362,37 @@ namespace Idler
                     Buttons.OkCancel) == Result.OK;
             }
             return true;
+        }
+
+        private void SaveWindowPosition()
+        {
+            Settings.Default.MainWindowMaximized = this.WindowState == WindowState.Maximized;
+
+            if (this.WindowState != WindowState.Maximized)
+            {
+                Settings.Default.MainWindowHeight = this.Height;
+                Settings.Default.MainWindowWidth = this.Width;
+                Settings.Default.MainWindowTop = this.Top;
+                Settings.Default.MainWindowLeft = this.Left;
+            }
+            else
+            {
+                Settings.Default.MainWindowHeight = RestoreBounds.Height;
+                Settings.Default.MainWindowWidth = RestoreBounds.Width;
+                Settings.Default.MainWindowTop = RestoreBounds.Top;
+                Settings.Default.MainWindowLeft = RestoreBounds.Left;
+            }
+
+            Settings.Default.Save();
+        }
+
+        private void RestoreWindowPosition()
+        {
+            this.Height = Settings.Default.MainWindowHeight;
+            this.Width = Settings.Default.MainWindowWidth;
+            this.Top = Settings.Default.MainWindowTop;
+            this.Left = Settings.Default.MainWindowLeft;
+            this.WindowState = Settings.Default.MainWindowMaximized ? WindowState.Maximized : WindowState.Normal;
         }
     }
 }

--- a/src/Idler/Properties/Settings.Designer.cs
+++ b/src/Idler/Properties/Settings.Designer.cs
@@ -153,5 +153,65 @@ namespace Idler.Properties {
                 this["SkipWeekends"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("450")]
+        public double MainWindowHeight {
+            get {
+                return ((double)(this["MainWindowHeight"]));
+            }
+            set {
+                this["MainWindowHeight"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("800")]
+        public double MainWindowWidth {
+            get {
+                return ((double)(this["MainWindowWidth"]));
+            }
+            set {
+                this["MainWindowWidth"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public double MainWindowLeft {
+            get {
+                return ((double)(this["MainWindowLeft"]));
+            }
+            set {
+                this["MainWindowLeft"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public double MainWindowTop {
+            get {
+                return ((double)(this["MainWindowTop"]));
+            }
+            set {
+                this["MainWindowTop"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool MainWindowMaximized {
+            get {
+                return ((bool)(this["MainWindowMaximized"]));
+            }
+            set {
+                this["MainWindowMaximized"] = value;
+            }
+        }
     }
 }

--- a/src/Idler/Properties/Settings.settings
+++ b/src/Idler/Properties/Settings.settings
@@ -35,5 +35,20 @@
     <Setting Name="SkipWeekends" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="MainWindowHeight" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">450</Value>
+    </Setting>
+    <Setting Name="MainWindowWidth" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">800</Value>
+    </Setting>
+    <Setting Name="MainWindowLeft" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="MainWindowTop" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="MainWindowMaximized" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
### Description of issue

Need to make the app save position and size of main window and restore it when user launch the app again

### Description of fix

1. added new settings:
  - MainWindowHeight
  - MainWindowWidth
  - MainWindowLeft
  - MainWindowTop
  - MainWindowMaximized
2. implemented logic to save size and position of main window before closing it
3. implemented logic to restore size and position of main window before its initialization

