### PR TITLE
Highligh dates if there are notes in date picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,13 @@ You can use blur functionality with disabled feature `Auto Blur`, just use `Lock
 You can easily export any range of notes to `Microsoft Excel` format. It can be done via top menu `File -> Export...`, you will need only specify date range and path to file to save. It will create table with columns: `Id`, `Category`, `Effort`, `Description` and `Date`. 
 
 If you need some specific structure of result Excel file, you can specify Excel Template in settings and then enable check box `Use Template` before pressing button `Export`. You can specify follow placeholders in the template which will be replaced with corresponding data: `{{notes.Id}}`, `{{notes.Category}}`, `{{notes.Effort}}`, `{{notes.Description}}` and `{{notes.Date}}`. Please see full template specification and examples [here](https://github.com/mini-software/MiniExcel/tree/1.31.1-1.31.2#fill-data-to-excel-template-)
+
+### Work days highlighting
+
+To check that you filled your work progress fully, you can enable work days highlighting in the calendar which appears at date picker on the main window. Following color schema is used:
+
+- `yellow` - partially filled day (total effort is between `0` and specified `Work Load`)
+- `green` - day fully filled (total effort is equal or greater then specified `Work Load`)
+- `red` - overtime is detected (only when setting `Highlight Overtime` is enabled and total effort is greater then specified `Work Load`)
+
+`Work Load` can be set in application settings. If it equals to `0` then the feature will be disabled, alternatively you can disable it explicitly by unchecking a corresponding check box `Is Enabled`.

--- a/src/Idler/App.config
+++ b/src/Idler/App.config
@@ -71,7 +71,7 @@
       <setting name="DailyWorkLoad" serializeAs="String">
         <value>8</value>
       </setting>
-      <setting name="OvertimeWarning" serializeAs="String">
+      <setting name="IsOvertimeHighlighted" serializeAs="String">
         <value>False</value>
       </setting>
       <setting name="IsHighlightingEnabled" serializeAs="String">

--- a/src/Idler/App.config
+++ b/src/Idler/App.config
@@ -68,6 +68,15 @@
       <setting name="MainWindowMaximized" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="DailyWorkLoad" serializeAs="String">
+        <value>8</value>
+      </setting>
+      <setting name="OvertimeWarning" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="IsHighlightingEnabled" serializeAs="String">
+        <value>False</value>
+      </setting>
     </Idler.Properties.Settings>
   </userSettings>
 </configuration>

--- a/src/Idler/Converters/TotalEffortToColorConverter.cs
+++ b/src/Idler/Converters/TotalEffortToColorConverter.cs
@@ -12,6 +12,11 @@ namespace Idler.Converters
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
+            if (Properties.Settings.Default.DailyWorkLoad == 0 || !Properties.Settings.Default.IsHighlightingEnabled)
+            {
+                return Color.Empty.ToMediaColor();
+            }
+
             int? colorInt = null;
 
             if (values.Length == 2)
@@ -26,17 +31,19 @@ namespace Idler.Converters
                         {
                             colorInt = (int)TotalEffortType.None;
                         }
-                        if (totalEffort > 0 && totalEffort < 8)
+                        if (totalEffort > 0 && totalEffort < Properties.Settings.Default.DailyWorkLoad)
                         {
                             colorInt = (int)TotalEffortType.Parttime;
                         }
-                        if (totalEffort == 8)
+                        if (totalEffort == Properties.Settings.Default.DailyWorkLoad)
                         {
                             colorInt = (int)TotalEffortType.CompleteShift;
                         }
-                        if (totalEffort > 8)
+                        if (totalEffort > Properties.Settings.Default.DailyWorkLoad)
                         {
-                            colorInt = (int)TotalEffortType.Overtime;
+                            colorInt = Properties.Settings.Default.OvertimeWarning 
+                                ? (int)TotalEffortType.Overtime 
+                                : (int)TotalEffortType.CompleteShift;
                         }
                     }
                 }

--- a/src/Idler/Converters/TotalEffortToColorConverter.cs
+++ b/src/Idler/Converters/TotalEffortToColorConverter.cs
@@ -27,24 +27,28 @@ namespace Idler.Converters
                     {
                         decimal totalEffort = datesToHighlight[date];
 
+                        var color = TotalEffortType.None;
+
                         if (totalEffort == 0)
                         {
-                            colorInt = (int)TotalEffortType.None;
+                            color = TotalEffortType.None;
                         }
                         if (totalEffort > 0 && totalEffort < Properties.Settings.Default.DailyWorkLoad)
                         {
-                            colorInt = (int)TotalEffortType.Parttime;
+                            color = TotalEffortType.Parttime;
                         }
                         if (totalEffort == Properties.Settings.Default.DailyWorkLoad)
                         {
-                            colorInt = (int)TotalEffortType.CompleteShift;
+                            color = TotalEffortType.CompleteShift;
                         }
                         if (totalEffort > Properties.Settings.Default.DailyWorkLoad)
                         {
-                            colorInt = Properties.Settings.Default.IsOvertimeHighlighted 
-                                ? (int)TotalEffortType.Overtime 
-                                : (int)TotalEffortType.CompleteShift;
+                            color = Properties.Settings.Default.IsOvertimeHighlighted 
+                                ? TotalEffortType.Overtime 
+                                : TotalEffortType.CompleteShift;
                         }
+
+                        colorInt = date == DateTime.Today ? color.GetDarkerColor() : (int)color;
                     }
                 }
             }

--- a/src/Idler/Converters/TotalEffortToColorConverter.cs
+++ b/src/Idler/Converters/TotalEffortToColorConverter.cs
@@ -41,7 +41,7 @@ namespace Idler.Converters
                         }
                         if (totalEffort > Properties.Settings.Default.DailyWorkLoad)
                         {
-                            colorInt = Properties.Settings.Default.OvertimeWarning 
+                            colorInt = Properties.Settings.Default.IsOvertimeHighlighted 
                                 ? (int)TotalEffortType.Overtime 
                                 : (int)TotalEffortType.CompleteShift;
                         }

--- a/src/Idler/Converters/TotalEffortToColorConverter.cs
+++ b/src/Idler/Converters/TotalEffortToColorConverter.cs
@@ -1,0 +1,55 @@
+﻿using Idler.Extensions;
+using Idler.Models;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Idler.Converters
+{
+    public class TotalEffortToColorConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            int? colorInt = null;
+
+            if (values.Length == 2)
+            {
+                if (values[1] is Dictionary<DateTime, decimal> datesToHighlight)
+                {
+                    if (values[0] is DateTime date && datesToHighlight.ContainsKey(date))
+                    {
+                        decimal totalEffort = datesToHighlight[date];
+
+                        if (totalEffort == 0)
+                        {
+                            colorInt = (int)TotalEffortType.None;
+                        }
+                        if (totalEffort > 0 && totalEffort < 8)
+                        {
+                            colorInt = (int)TotalEffortType.Parttime;
+                        }
+                        if (totalEffort == 8)
+                        {
+                            colorInt = (int)TotalEffortType.CompleteShift;
+                        }
+                        if (totalEffort > 8)
+                        {
+                            colorInt = (int)TotalEffortType.Overtime;
+                        }
+                    }
+                }
+            }
+
+            return colorInt == null 
+                ? Color.Empty.ToMediaColor() 
+                : ((Color)new ColorConverter().ConvertFromString($"#{colorInt:X}")).ToMediaColor();
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Idler/Extensions/ColorExtensions.cs
+++ b/src/Idler/Extensions/ColorExtensions.cs
@@ -1,13 +1,12 @@
-﻿using MColor = System.Windows.Media.Color;
-using DColor = System.Drawing.Color;
+﻿using System.Windows.Media;
 
 namespace Idler.Extensions
 {
     public static class ColorExtensions
     {
-        public static MColor ToMediaColor(this DColor color)
+        public static Color ToMediaColor(this System.Drawing.Color color)
         {
-            return MColor.FromArgb(color.A, color.R, color.G, color.B);
+            return Color.FromArgb(color.A, color.R, color.G, color.B);
         }
     }
 }

--- a/src/Idler/Extensions/ColorExtensions.cs
+++ b/src/Idler/Extensions/ColorExtensions.cs
@@ -1,0 +1,13 @@
+﻿using MColor = System.Windows.Media.Color;
+using DColor = System.Drawing.Color;
+
+namespace Idler.Extensions
+{
+    public static class ColorExtensions
+    {
+        public static MColor ToMediaColor(this DColor color)
+        {
+            return MColor.FromArgb(color.A, color.R, color.G, color.B);
+        }
+    }
+}

--- a/src/Idler/Extensions/CommonExtensions.cs
+++ b/src/Idler/Extensions/CommonExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Idler.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Idler.Extensions
+{
+    public static class CommonExtensions
+    {
+        public static int? GetDarkerColor(this TotalEffortType value)
+        {
+            Type enumType = value.GetType();
+            FieldInfo[] enumValues = enumType.GetFields();
+            FieldInfo foundValue = enumValues
+                .Where(field => field.IsLiteral && field.GetValue(null).Equals(value))
+                .FirstOrDefault();
+
+            if (foundValue == null)
+            {
+                return null;
+            }
+
+            var attribute = (DarkerColorAttribute)foundValue.GetCustomAttribute(typeof(DarkerColorAttribute));
+
+            return attribute?.Color;
+        }
+    }
+}

--- a/src/Idler/Idler.csproj
+++ b/src/Idler/Idler.csproj
@@ -120,11 +120,13 @@
     <Compile Include="Converters\HeightToCornerRadius.cs" />
     <Compile Include="Converters\TotalEffortToColorConverter.cs" />
     <Compile Include="Extensions\ColorExtensions.cs" />
+    <Compile Include="Extensions\CommonExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="Helpers\AdvancedTextWriterTraceListener.cs" />
     <Compile Include="Helpers\DB\DataBaseFunctions.cs" />
     <Compile Include="Helpers\MVVM\ObservableObject.cs" />
     <Compile Include="Helpers\MVVM\UpdatableObject.cs" />
+    <Compile Include="Models\DarkerColorAttribute.cs" />
     <Compile Include="Models\ShiftNote.cs" />
     <Compile Include="Models\TotalEffortType.cs" />
     <Compile Include="NoteCategory.cs" />

--- a/src/Idler/Idler.csproj
+++ b/src/Idler/Idler.csproj
@@ -118,12 +118,15 @@
     <Compile Include="Contracts\SelectedDateType.cs" />
     <Compile Include="Converters\DoubleConverter.cs" />
     <Compile Include="Converters\HeightToCornerRadius.cs" />
+    <Compile Include="Converters\TotalEffortToColorConverter.cs" />
+    <Compile Include="Extensions\ColorExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="Helpers\AdvancedTextWriterTraceListener.cs" />
     <Compile Include="Helpers\DB\DataBaseFunctions.cs" />
     <Compile Include="Helpers\MVVM\ObservableObject.cs" />
     <Compile Include="Helpers\MVVM\UpdatableObject.cs" />
     <Compile Include="Models\ShiftNote.cs" />
+    <Compile Include="Models\TotalEffortType.cs" />
     <Compile Include="NoteCategory.cs" />
     <Compile Include="SettingsWindow.xaml.cs">
       <DependentUpon>SettingsWindow.xaml</DependentUpon>

--- a/src/Idler/MainWindow.xaml
+++ b/src/Idler/MainWindow.xaml
@@ -22,7 +22,7 @@
                             <SolidColorBrush.Color>
                                 <MultiBinding Converter="{StaticResource TotalEffortToColorConverter}">
                                     <Binding />
-                                    <Binding Path="MonthlyTotalEffort" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=Window}" />
+                                    <Binding Path="DaysToHighlight" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=Window}" />
                                 </MultiBinding>
                             </SolidColorBrush.Color>
                         </SolidColorBrush>

--- a/src/Idler/MainWindow.xaml
+++ b/src/Idler/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Idler"
         xmlns:views="clr-namespace:Idler.Views"
+        xmlns:converters="clr-namespace:Idler.Converters"
         mc:Ignorable="d"
         DataContext="{Binding RelativeSource={RelativeSource Self}}"
         Title="{Binding FullAppName}"
@@ -12,6 +13,27 @@
     <Window.Resources>
         <CollectionViewSource x:Key="NoteCategoriesList"
                               Source="{Binding NoteCategories.Categories}" />
+        <converters:TotalEffortToColorConverter x:Key="TotalEffortToColorConverter" />
+        <Style x:Key="HighlightedCalendarDayButtonStyle" TargetType="{x:Type CalendarDayButton}" BasedOn="{StaticResource {x:Type CalendarDayButton}}">
+            <Style.Setters>
+                <Setter Property="Background">
+                    <Setter.Value>
+                        <SolidColorBrush>
+                            <SolidColorBrush.Color>
+                                <MultiBinding Converter="{StaticResource TotalEffortToColorConverter}">
+                                    <Binding />
+                                    <Binding Path="MonthlyTotalEffort" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=Window}" />
+                                </MultiBinding>
+                            </SolidColorBrush.Color>
+                        </SolidColorBrush>
+                    </Setter.Value>
+                </Setter>
+            </Style.Setters>
+        </Style>
+
+        <Style x:Key="CalendarWithHighlightedWorkDays" TargetType="{x:Type Calendar}" BasedOn="{StaticResource {x:Type Calendar}}">
+            <Setter Property="CalendarDayButtonStyle" Value="{StaticResource HighlightedCalendarDayButtonStyle}" />
+        </Style>
     </Window.Resources>
     <Window.InputBindings>
         <KeyBinding Modifiers="Control"
@@ -90,7 +112,9 @@
                     <DatePicker Margin="5,0"
                                 DockPanel.Dock="Left"
                                 SelectedDate="{Binding SelectedDate}" 
-                                VerticalContentAlignment="Center" />
+                                DisplayDate="{Binding DisplayDate}"
+                                VerticalContentAlignment="Center"
+                                CalendarStyle="{StaticResource CalendarWithHighlightedWorkDays}" />
                     <Button x:Name="btnNextShift"
                             Padding="25,5"
                             Margin="0,0,25,0"

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -450,6 +450,15 @@ namespace Idler
 
         private void FetchMonthlyTotalEffort(int month, int year)
         {
+            if (!Settings.Default.IsHighlightingEnabled || Settings.Default.DailyWorkLoad == 0)
+            {
+                if (this.MonthlyTotalEffort.Count == 0)
+                {
+                    this.MonthlyTotalEffort = new Dictionary<DateTime, decimal>(0);
+                }
+                return;
+            }
+
             this.SafeAsyncCall(
                 DataBaseFunctions.GetMonthlyTotalEffort(month, year),
                 (result) =>

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -230,6 +230,13 @@ namespace Idler
             this.ExportNotesCommand = new RelayCommand(ExportNotesCommandHandler);
             this.ChangeSelectedDateCommand = new ChangeSelectedDateCommand(this);
             this.SafeAsyncCall(InitialLoadingShiftNotes(this.NoteCategories.Categories));
+            Settings.Default.SettingsSaving += this.OnSettignsChanging;
+        }
+
+        private void OnSettignsChanging(object sender, CancelEventArgs e)
+        {
+            // Forces the calendar control to recalculate highlighting
+            this.OnPropertyChanged(nameof(this.MonthlyTotalEffort));
         }
 
         private void WindowClosingHandler(object sender, CancelEventArgs e)
@@ -264,6 +271,7 @@ namespace Idler
                 case nameof(this.CurrentShift):
                     this.AddNoteViewModel.Shift = this.CurrentShift;
                     this.CurrentShift.PropertyChanged += CurrentShiftPropertyChanged;
+                    this.CurrentShift.RefreshCompleted += (s, a) => this.FetchMonthlyTotalEffort(this.DisplayDate.Month, this.DisplayDate.Year);
                     this.SaveShiftCommand = new SaveShiftCommand(this, this.CurrentShift);
                     this.RefreshNotesCommand = new RefreshNotesCommand(this.CurrentShift, this.DialogHost);
                     break;

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -1,10 +1,12 @@
 ﻿using Idler.Commands;
 using Idler.Components;
 using Idler.Components.PopupDialogControl;
+using Idler.Helpers.DB;
 using Idler.Properties;
 using Idler.ViewModels;
 using Idler.Views;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -34,6 +36,9 @@ namespace Idler
         private PopupDialogHost dialogHost;
         private ICommand exportNotesCommand;
         private ICommand changeSelectedDateCommand;
+        private Dictionary<DateTime, decimal> monthlyTotalEffort;
+        private bool loadingMonthlyTotalEffort;
+        private DateTime displayDate;
 
         public AddNoteViewModel AddNoteViewModel
         {
@@ -174,6 +179,36 @@ namespace Idler
             }
         }
 
+        public Dictionary<DateTime, decimal> MonthlyTotalEffort
+        {
+            get => monthlyTotalEffort;
+            set
+            {
+                monthlyTotalEffort = value;
+                this.OnPropertyChanged(nameof(this.MonthlyTotalEffort));
+            }
+        }
+
+        public bool LoadingMonthlyTotalEffort
+        { 
+            get => loadingMonthlyTotalEffort;
+            set
+            {
+                loadingMonthlyTotalEffort = value;
+                this.OnPropertyChanged(nameof(this.MonthlyTotalEffort));
+            }
+        }
+
+        public DateTime DisplayDate 
+        { 
+            get => displayDate;
+            set
+            {
+                displayDate = value;
+                this.OnPropertyChanged(nameof(this.DisplayDate));
+            }
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         public MainWindow()
@@ -249,6 +284,9 @@ namespace Idler
                         this.CurrentShift.SelectedDate = this.SelectedDate;
                         this.SafeAsyncCall(this.CurrentShift.RefreshAsync());
                     }
+                    break;
+                case nameof(this.DisplayDate):
+                    this.FetchMonthlyTotalEffort(this.DisplayDate.Month, this.DisplayDate.Year);
                     break;
             }
         }
@@ -393,6 +431,16 @@ namespace Idler
             this.Top = Settings.Default.MainWindowTop;
             this.Left = Settings.Default.MainWindowLeft;
             this.WindowState = Settings.Default.MainWindowMaximized ? WindowState.Maximized : WindowState.Normal;
+        }
+
+        private void FetchMonthlyTotalEffort(int month, int year)
+        {
+            this.SafeAsyncCall(
+                DataBaseFunctions.GetMonthlyTotalEffort(month, year),
+                (result) =>
+                {
+                    this.MonthlyTotalEffort = result;
+                });
         }
     }
 }

--- a/src/Idler/MainWindow.xaml.cs
+++ b/src/Idler/MainWindow.xaml.cs
@@ -288,6 +288,13 @@ namespace Idler
                 case nameof(this.DisplayDate):
                     this.FetchMonthlyTotalEffort(this.DisplayDate.Month, this.DisplayDate.Year);
                     break;
+                case nameof(this.TotalEffort):
+                    if (this.MonthlyTotalEffort != null && this.MonthlyTotalEffort.ContainsKey(this.SelectedDate.Date))
+                    {
+                        this.MonthlyTotalEffort[this.SelectedDate.Date] = this.TotalEffort;
+                        this.OnPropertyChanged(nameof(this.MonthlyTotalEffort));
+                    }
+                    break;
             }
         }
 

--- a/src/Idler/Models/DarkerColorAttribute.cs
+++ b/src/Idler/Models/DarkerColorAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Idler.Models
+{
+    public class DarkerColorAttribute : Attribute
+    {
+        public int Color { get; set; }
+
+        public DarkerColorAttribute(int color)
+        {
+            this.Color = color;
+        }
+    }
+}

--- a/src/Idler/Models/TotalEffortType.cs
+++ b/src/Idler/Models/TotalEffortType.cs
@@ -8,9 +8,16 @@ namespace Idler.Models
 {
     public enum TotalEffortType
     {
+        [DarkerColor(0xaaaaaa)]
         None = 0xffffff,
+
+        [DarkerColor(0xfec500)]
         Parttime = 0xfff8e0,
+
+        [DarkerColor(0x15d6a0)]
         CompleteShift = 0xc3f9ea,
+
+        [DarkerColor(0xf35934)]
         Overtime = 0xfde4de
     }
 }

--- a/src/Idler/Models/TotalEffortType.cs
+++ b/src/Idler/Models/TotalEffortType.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Idler.Models
+{
+    public enum TotalEffortType
+    {
+        None = 0xffffff,
+        Parttime = 0xfff8e0,
+        CompleteShift = 0xc3f9ea,
+        Overtime = 0xfde4de
+    }
+}

--- a/src/Idler/Properties/Settings.Designer.cs
+++ b/src/Idler/Properties/Settings.Designer.cs
@@ -213,5 +213,41 @@ namespace Idler.Properties {
                 this["MainWindowMaximized"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("8")]
+        public decimal DailyWorkLoad {
+            get {
+                return ((decimal)(this["DailyWorkLoad"]));
+            }
+            set {
+                this["DailyWorkLoad"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool OvertimeWarning {
+            get {
+                return ((bool)(this["OvertimeWarning"]));
+            }
+            set {
+                this["OvertimeWarning"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool IsHighlightingEnabled {
+            get {
+                return ((bool)(this["IsHighlightingEnabled"]));
+            }
+            set {
+                this["IsHighlightingEnabled"] = value;
+            }
+        }
     }
 }

--- a/src/Idler/Properties/Settings.Designer.cs
+++ b/src/Idler/Properties/Settings.Designer.cs
@@ -229,12 +229,12 @@ namespace Idler.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool OvertimeWarning {
+        public bool IsOvertimeHighlighted {
             get {
-                return ((bool)(this["OvertimeWarning"]));
+                return ((bool)(this["IsOvertimeHighlighted"]));
             }
             set {
-                this["OvertimeWarning"] = value;
+                this["IsOvertimeHighlighted"] = value;
             }
         }
         

--- a/src/Idler/Properties/Settings.settings
+++ b/src/Idler/Properties/Settings.settings
@@ -50,5 +50,14 @@
     <Setting Name="MainWindowMaximized" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="DailyWorkLoad" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">8</Value>
+    </Setting>
+    <Setting Name="OvertimeWarning" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="IsHighlightingEnabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/Idler/Properties/Settings.settings
+++ b/src/Idler/Properties/Settings.settings
@@ -53,7 +53,7 @@
     <Setting Name="DailyWorkLoad" Type="System.Decimal" Scope="User">
       <Value Profile="(Default)">8</Value>
     </Setting>
-    <Setting Name="OvertimeWarning" Type="System.Boolean" Scope="User">
+    <Setting Name="IsOvertimeHighlighted" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="IsHighlightingEnabled" Type="System.Boolean" Scope="User">

--- a/src/Idler/SettingsWindow.xaml
+++ b/src/Idler/SettingsWindow.xaml
@@ -120,7 +120,7 @@
                        Margin="5"/>
             <CheckBox Content="Highlight Overtime"
                       VerticalAlignment="Center"
-                      IsChecked="{Binding OvertimeWarning, UpdateSourceTrigger=PropertyChanged, Source={x:Static properties:Settings.Default}}"
+                      IsChecked="{Binding IsOvertimeHighlighted, UpdateSourceTrigger=PropertyChanged, Source={x:Static properties:Settings.Default}}"
                       DockPanel.Dock="Right"
                       IsEnabled="{Binding IsHighlightingEnabled, UpdateSourceTrigger=PropertyChanged, Source={x:Static properties:Settings.Default}}"
                       Margin="5,0,0,0" />

--- a/src/Idler/SettingsWindow.xaml
+++ b/src/Idler/SettingsWindow.xaml
@@ -7,13 +7,15 @@
         xmlns:properties="clr-namespace:Idler.Properties"
         DataContext="{Binding RelativeSource={RelativeSource Self}}"
         mc:Ignorable="d"
-        Title="Settings" Height="352" Width="499">
+        Title="Settings" Height="450" Width="550">
     <Grid Margin="5">
         <Grid.RowDefinitions>
-            <RowDefinition Height ="auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="5"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="5"/>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="5" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="5" />
             <RowDefinition Height="Auto" />
@@ -100,8 +102,36 @@
                   IsChecked="{Binding SkipWeekends, Source={x:Static properties:Settings.Default}}">
         </CheckBox>
 
-        <TextBlock Padding="0,5" Text="Note Categories:" DockPanel.Dock="Top" Grid.Row="10" Grid.Column="0"/>
-        <DataGrid Grid.Row="12" Grid.ColumnSpan="3" AutoGenerateColumns="False" ItemsSource="{Binding NoteCategories.Categories}">
+        <TextBlock Text="Days Highlighting" 
+                   Grid.Column="0" 
+                   Grid.Row="10" 
+                   VerticalAlignment="Center" 
+                   Padding="0,5" />
+        <DockPanel Grid.Column="2" 
+                   Grid.Row="10">
+            <CheckBox Content="Is Enabled"
+                      VerticalAlignment="Center"
+                      IsChecked="{Binding IsHighlightingEnabled, UpdateSourceTrigger=PropertyChanged, Source={x:Static properties:Settings.Default}}"
+                      DockPanel.Dock="Right" />
+            <Rectangle VerticalAlignment="Stretch"
+                       DockPanel.Dock="Right" 
+                       Fill="LightGray" 
+                       Width="1"
+                       Margin="5"/>
+            <CheckBox Content="Highlight Overtime"
+                      VerticalAlignment="Center"
+                      IsChecked="{Binding OvertimeWarning, UpdateSourceTrigger=PropertyChanged, Source={x:Static properties:Settings.Default}}"
+                      DockPanel.Dock="Right"
+                      IsEnabled="{Binding IsHighlightingEnabled, UpdateSourceTrigger=PropertyChanged, Source={x:Static properties:Settings.Default}}"
+                      Margin="5,0,0,0" />
+            <TextBox x:Name="txtWorkHoursAmount"
+                     VerticalContentAlignment="Center"
+                     IsEnabled="{Binding IsHighlightingEnabled, UpdateSourceTrigger=PropertyChanged, Source={x:Static properties:Settings.Default}}"
+                     Text="{Binding DailyWorkLoad, UpdateSourceTrigger=PropertyChanged, Source={x:Static properties:Settings.Default}}" />
+        </DockPanel>
+
+        <TextBlock Padding="0,5" Text="Note Categories:" DockPanel.Dock="Top" Grid.Row="12" Grid.Column="0"/>
+        <DataGrid Grid.Row="14" Grid.ColumnSpan="3" AutoGenerateColumns="False" ItemsSource="{Binding NoteCategories.Categories}">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Name" Binding="{Binding Name}" />
                 <DataGridCheckBoxColumn Header="Hidden" Binding="{Binding Hidden}" />
@@ -116,7 +146,7 @@
                 </Style>
             </DataGrid.RowStyle>
         </DataGrid>
-        <DockPanel Grid.Row="14" Grid.ColumnSpan="3" LastChildFill="False">
+        <DockPanel Grid.Row="16" Grid.ColumnSpan="3" LastChildFill="False">
             <Button x:Name="btnReset" Content="Reset" Padding="25,5" DockPanel.Dock="Right" Click="btnReset_Click" Height="28" VerticalAlignment="Bottom" IsEnabled="{Binding AreSettingsUnsaved}" />
             <Button x:Name="btnSave" Content="Save" Padding="25,5" DockPanel.Dock="Right" Margin="0,0,5,0" Click="btnSave_Click" IsEnabled="{Binding AreSettingsUnsaved}"/>
             <Button x:Name="btnDefault" Content="Return to default" Padding="25,5" DockPanel.Dock="Right" Margin="0,0,5,0" Click="btnDefault_Click"/>


### PR DESCRIPTION
### Change Log

- added new settings:
  - DailyWorkLoad - work load for one day
  - IsOvertimeHighlighted - enables highlighting of overtimes
  - IsHighlightingEnabled - enables highlighting of work days
- applied style for day button in calendar components which uses converter `TotalEffortToColorConverter` to convert total effort to color
- added DB function to get total effort for every day in specified month